### PR TITLE
Simplify codecov actions

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -35,10 +35,11 @@ jobs:
       - name: Install ampworks
         run: |
           python -m pip install --upgrade pip
+          python -m pip install --upgrade nox
           pip install .[tests]
 
-      - name: Pytest with coverage
-        run: pytest --cov=ampworks --cov-report=xml tests/
+      - name: Collect coverage
+        run: nox -s tests
 
       - name: Upload to codecov
         uses: codecov/codecov-action@v5
@@ -47,6 +48,6 @@ jobs:
           verbose: true
           flags: unittests
           env_vars: OS,PYTHON
-          files: ./coverage.xml
           name: codecov-umbrella
           fail_ci_if_error: false
+          files: ./reports/coverage.xml

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -39,7 +39,7 @@ jobs:
           pip install .[tests]
 
       - name: Collect coverage
-        run: nox -s tests
+        run: nox -s tests -- codecov
 
       - name: Upload to codecov
         uses: codecov/codecov-action@v5
@@ -48,6 +48,6 @@ jobs:
           verbose: true
           flags: unittests
           env_vars: OS,PYTHON
+          files: ./coverage.xml
           name: codecov-umbrella
           fail_ci_if_error: false
-          files: ./reports/coverage.xml

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,6 +1,5 @@
 import os
 import shutil
-import importlib
 
 import nox
 
@@ -89,13 +88,10 @@ def run_pytest(session: nox.Session) -> None:
     you can specify the number of workers using an int, e.g., parallel=4.
 
     """
-    package = importlib.util.find_spec('ampworks')
-    coverage_folder = os.path.dirname(package.origin)
-
     if 'no-reports' in session.posargs:
         command = [
             'pytest',
-            f'--cov={coverage_folder}',  # for editable or site-packages
+            '--cov=ampworks',
             'tests/',
         ]
     else:
@@ -103,7 +99,7 @@ def run_pytest(session: nox.Session) -> None:
 
         command = [
             'pytest',
-            '--cov=src/ampworks',
+            '--cov=ampworks',
             '--cov-report=html:reports/htmlcov',
             '--cov-report=xml:reports/coverage.xml',
             '--junitxml=reports/junit.xml',

--- a/noxfile.py
+++ b/noxfile.py
@@ -100,6 +100,7 @@ def run_pytest(session: nox.Session) -> None:
         command = [
             'pytest',
             '--cov=ampworks',
+            '--cov-config=pyproject.toml',
             '--cov-report=html:reports/htmlcov',
             '--cov-report=xml:reports/coverage.xml',
             '--junitxml=reports/junit.xml',

--- a/noxfile.py
+++ b/noxfile.py
@@ -94,13 +94,19 @@ def run_pytest(session: nox.Session) -> None:
             '--cov=ampworks',
             'tests/',
         ]
+    elif 'codecov' in session.posargs:
+        command = [
+            'pytest',
+            '--cov=ampworks',
+            '--cov-report=xml',
+            'tests/',
+        ]
     else:
         os.makedirs('reports', exist_ok=True)
 
         command = [
             'pytest',
             '--cov=ampworks',
-            '--cov-config=pyproject.toml',
             '--cov-report=html:reports/htmlcov',
             '--cov-report=xml:reports/coverage.xml',
             '--junitxml=reports/junit.xml',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,9 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*" = ["D"]
 
+[tool.coverage.run]
+relative_files = true
+
 [project.optional-dependencies]
 gui = [
     "dash",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,9 +79,6 @@ ignore = [
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*" = ["D"]
 
-[tool.coverage.run]
-relative_files = true
-
 [project.optional-dependencies]
 gui = [
     "dash",


### PR DESCRIPTION
# Description
Tie in nox to codecov workflow. New `-- codecov` argument for the `nox` session is used for this purpose. This keeps commands together in one conventient location rather than spread across many workflows/files.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that improves speed/readability/etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (any other clean up, maintenance, etc.)

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.