### PR TITLE
Fix issue when headers are parsed and a NaN is encountered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Added tests for `ici.extract_params` ([#5](https://github.com/NatLabRockies/ampworks/pull/5))
 
 ### Bug Fixes
+- Catch when `NaN` is present when parsing for headers in excel files ([#23](https://github.com/NatLabRockies/ampworks/pull/23))
 - Force the `cell` dataset of the `DqdvFitter` to require an Ah column ([#19](https://github.com/NatLabRockies/ampworks/pull/19))
 - Update patching policy for releases, use `spellcheck` in nox pre-commit ([#13](https://github.com/NatLabRockies/ampworks/pull/13))
 - Readers missing name-only columns, e.g., `testtime` ([#8](https://github.com/NatLabRockies/ampworks/pull/8))

--- a/images/coverage.svg
+++ b/images/coverage.svg
@@ -1,5 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="116" height="20" role="img" aria-label="coverage: 30.09%">
-	<title>coverage: 30.09%</title>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="116" height="20" role="img" aria-label="coverage: 30.07%">
+	<title>coverage: 30.07%</title>
 	<linearGradient id="s" x2="0" y2="100%">
 		<stop offset="0" stop-color="#bbb" stop-opacity=".1"/>
 		<stop offset="1" stop-opacity=".1"/>
@@ -15,7 +15,7 @@
 	<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" text-rendering="geometricPrecision" font-size="110">
 		<text aria-hidden="true" x="315.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="510">coverage</text>
 		<text x="315.0" y="140" transform="scale(.1)" fill="#fff" textLength="510">coverage</text>
-		<text aria-hidden="true" x="875.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="450">30.09%</text>
-		<text x="875.0" y="140" transform="scale(.1)" fill="#fff" textLength="450">30.09%</text>
+		<text aria-hidden="true" x="875.0" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="450">30.07%</text>
+		<text x="875.0" y="140" transform="scale(.1)" fill="#fff" textLength="450">30.07%</text>
 	</g>
 </svg>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,11 +68,11 @@ select = [
     "D",  # All pydocstyle checks
 ]
 extend-select = [
-    "E302",  # Expected 2 blank lines, found 1 (requires preview=true, above)
+    "E302", "E305",  # Expected blank lines (requires preview=true, above)
 ]
 ignore = [
-    "B007", "B009", "B028", "B905",
-    "D100", "D103", "D104", "D203", "D205", "D212", "D401",
+    "B007", "B009", "B010", "B028", "B905",
+    "D1", "D203", "D205", "D212", "D400", "D401", "D415",
     "E201", "E202", "E226", "E241", "E731",
 ]
 

--- a/src/ampworks/__init__.py
+++ b/src/ampworks/__init__.py
@@ -18,7 +18,7 @@ docstrings from a package, module, function, class, etc. You can also access
 the documentation by visiting the website, hosted on Read the Docs. The website
 includes search functionality and more detailed examples.
 
-"""  # noqa: D400, D415 (ignore missing punctuation on first line)
+"""
 
 from typing import TYPE_CHECKING
 

--- a/src/ampworks/_core/_read.py
+++ b/src/ampworks/_core/_read.py
@@ -198,11 +198,11 @@ def read_excel(
     workbook = pd.ExcelFile(filepath)
     all_sheets = workbook.sheet_names
     num_sheets = len(all_sheets)
-    
+
     # warn if 'all' matches a sheet name
-    if sheet_name == 'all' and 'all' in all_sheets: 
+    if sheet_name == 'all' and 'all' in all_sheets:
         warn()
-    
+
     # Set which sheets to iterate through
     if sheet_name is None or sheet_name == 'all':
         iter_sheets = all_sheets
@@ -215,7 +215,7 @@ def read_excel(
             "'sheet_name' expected a str, int, list[str, int], or None, but"
             f" got {type(sheet_name)}."
         )
-        
+
     # Raise errors if invalid indices/names
     indices = [v for v in iter_sheets if isinstance(v, int)]
     strings = [v for v in iter_sheets if isinstance(v, str)]


### PR DESCRIPTION
# Description
For excel files with NaN in a given row the `find_headers` function would break because even when the row is converted to a `str`, the NaN remains a `float`. This has now been fixed by replacing NaN with empty strings during header parsing.

This PR also includes some minor changes to the error codes that ruff checks for.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that improves speed/readability/etc.)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (any other clean up, maintenance, etc.)

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`
- [x] Badges are updated: `$ nox -s badges`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.