### PR TITLE
Add checks module and cleanup code, prep for labels module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/NatLabRockies/ampworks)
 
 ### New Features
+- New `_checks` module to help developers streamline raising some exceptions ([#25](https://github.com/NatLabRockies/ampworks/pull/25))
 - Change backend `read` functions to use `polars`, improving read speeds ([#24](https://github.com/NatLabRockies/ampworks/pull/24))
 - New `ocv` module with `match_peaks` function and supporting `DqdvSpline` ([#14](https://github.com/NatLabRockies/ampworks/pull/14))
 - Add `hppc` subpackage to extract impedance from HPPC protocols ([#12](https://github.com/NatLabRockies/ampworks/pull/12))

--- a/src/ampworks/_checks.py
+++ b/src/ampworks/_checks.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ampworks import Dataset
+    from typing import Any, Set, Sequence, Type
+
+__all__ = [
+    '_check_literal',
+    '_check_columns',
+    '_check_type',
+    '_check_inner_type',
+    '_check_only_one',
+]
+
+
+def _check_literal(name: str, value: Any, expected: Set[Any]) -> None:
+    """
+    Check that a value is in a set of expected literals.
+
+    Parameters
+    ----------
+    name : str
+        Name of the parameter being checked, used in error messages.
+    value : Any
+        Value of the parameter being checked.
+    expected : Set[Any]
+        Set of expected literal values.
+
+    Raises
+    ------
+    ValueError
+        Value was not in expected set of literals.
+
+    """
+    if value not in expected:
+        raise ValueError(f"'{name}' must be one of {expected}, got {value}.")
+
+
+def _check_columns(data: Dataset, columns: Sequence[str]) -> None:
+    """
+    Check that a dataset contains required columns.
+
+    Parameters
+    ----------
+    data : Dataset
+        A dataset whose columns will be checked against those required.
+    columns : Sequence[str]
+        A sequence of column names required for a processing function.
+
+    Raises
+    ------
+    ValueError
+        If the data is missing columns required for a processing function.
+
+    """
+    missing = list(set(columns) - set(data.columns))
+    if missing:
+        raise ValueError(f"'data' requires {columns=}, but {missing=}.")
+
+
+def _check_type(name: str, value: Any, expected: Type | tuple[Type]) -> None:
+    """
+    Check the type of a parameter against expected type(s).
+
+    Parameters
+    ----------
+    name : str
+        Name of the parameter being checked, used in error messages.
+    value : Any
+        Value of the parameter being checked.
+    expected : Type or tuple[Type]
+        The expected type(s) for the parameter.
+
+    Raises
+    ------
+    TypeError
+        If the parameter is not one of the expected types.
+
+    """
+    if isinstance(expected, tuple):
+        correction = [t if t is not None else type(None) for t in expected]
+        exp_names = "(" + ", ".join(t.__name__ for t in correction) + ")"
+    else:
+        expected = (expected,)  # Ensure expected is a tuple for uniformity
+        correction = [t if t is not None else type(None) for t in expected]
+        exp_names = correction[0].__name__
+
+    act_name = type(value).__name__
+    if not isinstance(value, tuple(correction)):
+        raise TypeError(f"'{name}' must be type {exp_names}, got {act_name}.")
+
+
+def _check_inner_type(
+    name: str,
+    value: Sequence[Any],
+    expected: Type | tuple[Type],
+) -> None:
+    """
+    Check the type of items within a sequence against an expected type.
+
+    Note that this function only checks the types within the sequence, not the
+    type of the sequence itself. If it is necessary to check the "outer" type of
+    the sequence, use `_check_type`.
+
+    Parameters
+    ----------
+    name : str
+        Name of the parameter being checked, used in error messages.
+    value : Sequence[Any]
+        Sequence of values to be checked.
+    expected : Type or tuple[Type]
+        Expected type(s) for each item in the sequence.
+
+    Raises
+    ------
+    TypeError
+        If any object(s) within the sequence don't match the expected type.
+
+    """
+    if isinstance(expected, tuple):
+        exp_names = "(" + ", ".join([t.__name__ for t in expected]) + ")"
+    else:
+        exp_names = expected.__name__
+        expected = (expected,)
+
+    if not all(isinstance(item, expected) for item in value):
+        raise TypeError(f"All items in '{name}' must be type {exp_names}.")
+
+
+def _check_only_one(conditions: Sequence[bool], message: str) -> None:
+    """
+    Check that exactly one condition in a sequence of conditions is True.
+
+    Parameters
+    ----------
+    conditions : Sequence[bool]
+        A sequence of boolean conditions to check.
+    message : str
+        Error message to raise if not exactly one condition is True.
+
+    Raises
+    ------
+    ValueError
+        If not exactly one condition is True. A custom error message is provided
+        to clarify the expected conditions.
+
+    """
+    if sum(conditions) != 1:
+        raise ValueError(message)

--- a/src/ampworks/_core/_dataset.py
+++ b/src/ampworks/_core/_dataset.py
@@ -101,8 +101,12 @@ class Dataset(pd.DataFrame):
             sample3 = data.downsample(resolution=('Volts', 1e-3))
 
         """
-        if sum(x is not None for x in [n, frac, resolution]) != 1:
-            raise ValueError("Specify exactly one of: n, frac, resolution.")
+        from ampworks._checks import _check_only_one
+
+        _check_only_one(
+            conditions=[x is not None for x in [n, frac, resolution]],
+            message="Specify exactly one of: n, frac, resolution.",
+        )
 
         if monotonic:
             warn("'monotonic' option is not yet implemented.")

--- a/src/ampworks/_core/_read.py
+++ b/src/ampworks/_core/_read.py
@@ -203,6 +203,7 @@ def read_excel(
 ) -> Dataset:
     """Read excel file."""
     from ampworks import Dataset
+    from ampworks._checks import _check_type, _check_inner_type
 
     workbook = pd.ExcelFile(filepath)
     all_sheets = workbook.sheet_names
@@ -213,31 +214,28 @@ def read_excel(
         warn()
 
     # Set which sheets to iterate through
+    _check_type('sheet_name', sheet_name, (str, int, Sequence, None))
+
     if sheet_name is None or sheet_name == 'all':
         iter_sheets = all_sheets
     elif isinstance(sheet_name, (str, int)):
         iter_sheets = [sheet_name]
     elif isinstance(sheet_name, Sequence):
         iter_sheets = list(sheet_name)
-    else:
-        raise TypeError(
-            "'sheet_name' expected a str, int, list[str, int], or None, but"
-            f" got {type(sheet_name)}."
-        )
 
     # Raise errors if invalid indices/names
-    indices = [v for v in iter_sheets if isinstance(v, int)]
-    strings = [v for v in iter_sheets if isinstance(v, str)]
-    others = [v for v in iter_sheets if not isinstance(v, (int, str))]
+    _check_inner_type('sheet_name', iter_sheets, (str, int))
 
-    bad_ind = [i for i in indices if not -num_sheets <= i < num_sheets]
+    strings = [v for v in iter_sheets if isinstance(v, str)]
+    indices = [v for v in iter_sheets if isinstance(v, int)]
+
     bad_str = [s for s in strings if s not in all_sheets]
-    if bad_ind:
-        raise ValueError(f"Invalid sheet indices {bad_ind}, has {num_sheets}")
+    bad_ind = [i for i in indices if not -num_sheets <= i < num_sheets]
+
     if bad_str:
         raise ValueError(f"Invalid worksheet names {bad_str}")
-    if others:
-        raise TypeError("'sheet_name' must only contain str and/or int types")
+    if bad_ind:
+        raise ValueError(f"Invalid sheet indices {bad_ind}, has {num_sheets}")
 
     # Iterate through select sheets
     failed = []

--- a/src/ampworks/dqdv/__init__.py
+++ b/src/ampworks/dqdv/__init__.py
@@ -47,14 +47,11 @@ def run_gui(jupyter_mode: str = 'external', jupyter_height: int = 650) -> None:
     """
     from ampworks.dqdv.gui_files import _gui
     from ampworks import _in_interactive, _in_notebook
+    from ampworks._checks import _check_type, _check_literal
 
-    if not isinstance(jupyter_mode, str):
-        raise TypeError("'jupyter_mode' must be type str.")
-    elif jupyter_mode not in ['external', 'inline']:
-        raise ValueError("'jupyter_mode' must be in {'external', 'inline'}.")
-
-    if not isinstance(jupyter_height, int):
-        raise TypeError("'jupyter_height' must be type int.")
+    _check_type('jupyter_mode', jupyter_mode, str)
+    _check_type('jupyter_height', jupyter_height, int)
+    _check_literal('jupyter_mode', jupyter_mode, {'external', 'inline'})
 
     if not _in_notebook():
         jupyter_mode = 'external'

--- a/src/ampworks/dqdv/_dqdv_fitter.py
+++ b/src/ampworks/dqdv/_dqdv_fitter.py
@@ -357,8 +357,9 @@ class DqdvFitter:
         electrode.
 
         """
-        if which not in ['neg', 'pos', 'cell']:
-            raise ValueError("'which' must be in ['neg', 'pos', 'cell'].")
+        from ampworks._checks import _check_literal
+
+        _check_literal('which', which, {'neg', 'pos', 'cell'})
 
         spline = getattr(self, f"_ocv_{which[0]}")
         if spline is None:
@@ -398,8 +399,9 @@ class DqdvFitter:
         information to ensure you are evaluating each in the correct directions.
 
         """
-        if which not in ['neg', 'pos', 'cell']:
-            raise ValueError("'which' must be in ['neg', 'pos', 'cell'].")
+        from ampworks._checks import _check_literal
+
+        _check_literal('which', which, {'neg', 'pos', 'cell'})
 
         spline = getattr(self, f"_dvdq_{which[0]}")
         if spline is None:

--- a/src/ampworks/dqdv/_dqdv_spline.py
+++ b/src/ampworks/dqdv/_dqdv_spline.py
@@ -55,12 +55,10 @@ class DqdvSpline:
             Root mean square error between smoothed and raw voltages.
 
         """
-        options = ['auto', 'provided', 'integrated']
-        if capacity_method not in options:
-            raise ValueError(
-                f"'capacity_method' expected a value in {options} but received"
-                f" {capacity_method}."
-            )
+        from ampworks._checks import _check_literal
+
+        options = {'auto', 'provided', 'integrated'}
+        _check_literal('capacity_method', capacity_method, options)
 
         self._capacity_method = capacity_method
 
@@ -130,6 +128,8 @@ class DqdvSpline:
         meets these requirements if you choose to use it.
 
         """
+        from ampworks._checks import _check_columns
+
         data = data.reset_index(drop=True)
 
         # flag how to determine capacity
@@ -139,11 +139,7 @@ class DqdvSpline:
             use_Ah = self._capacity_method == 'provided'
 
         required = {'Ah', 'Volts'} if use_Ah else {'Seconds', 'Amps', 'Volts'}
-        if not required.issubset(data.columns):
-            raise ValueError(
-                f"Missing columns in 'data'. Expected at least {required} but"
-                f" received {set(data.columns)}."
-            )
+        _check_columns(data, required)
 
         # integrate to get Ah column, if needed or requested
         is_net_charge = data['Volts'].iloc[0] < data['Volts'].iloc[-1]

--- a/src/ampworks/dqdv/_tables.py
+++ b/src/ampworks/dqdv/_tables.py
@@ -64,11 +64,12 @@ class DqdvFitTable(RichTable):
             'extra_cols' must be type list[str].
 
         """
+        from ampworks._checks import _check_type
+
         if extra_cols is None:
             extra_cols = []
 
-        if not isinstance(extra_cols, list):
-            raise TypeError("'extra_cols' must be type list[str].")
+        _check_type('extra_cols', extra_cols, list)
 
         self._extra_cols = extra_cols
         data = {col: [] for col in self._required_cols + self._extra_cols}

--- a/src/ampworks/gitt/_extract_params.py
+++ b/src/ampworks/gitt/_extract_params.py
@@ -112,17 +112,17 @@ def extract_params(data: Dataset, radius: float, tmin: float = 1,
     >>> print(stats)
 
     """
-    required = ['Seconds', 'Amps', 'Volts']
-    if not all(col in data.columns for col in required):
-        raise ValueError(f"'data' is missing columns, {required=}.")
+    from ampworks._checks import _check_columns, _check_only_one
+
+    _check_columns(data, {'Seconds', 'Amps', 'Volts'})
 
     charging = any(data['Amps'] > 0.)
     discharging = any(data['Amps'] < 0.)
 
-    if charging and discharging:
-        raise ValueError(
-            "'data' should not include both charge and discharge segments."
-        )
+    _check_only_one(
+        conditions=[charging, discharging],
+        message="'data' cannot include both charge and discharge segments.",
+    )
 
     df = data.copy()
     df = df.reset_index(drop=True)

--- a/src/ampworks/hppc/_extract_impedance.py
+++ b/src/ampworks/hppc/_extract_impedance.py
@@ -362,10 +362,10 @@ def extract_impedance(
     >>> print(impedance)
 
     """
+    from ampworks._checks import _check_columns
+
     # Validate required columns
-    required = ['Seconds', 'Amps', 'Volts']
-    if not all(col in data.columns for col in required):
-        raise ValueError(f"'data' is missing columns, {required=}.")
+    _check_columns(data, {'Seconds', 'Volts', 'Amps'})
 
     # Ensure consistency when 'steps' is provided
     if (steps is not None) and ('Step' not in data.columns):

--- a/src/ampworks/ici/_extract_params.py
+++ b/src/ampworks/ici/_extract_params.py
@@ -109,17 +109,17 @@ def extract_params(data: Dataset, radius: float, tmin: float = 1,
     >>> print(stats)
 
     """
-    required = ['Seconds', 'Amps', 'Volts']
-    if not all(col in data.columns for col in required):
-        raise ValueError(f"'data' is missing columns, {required=}.")
+    from ampworks._checks import _check_columns, _check_only_one
+
+    _check_columns(data, {'Seconds', 'Amps', 'Volts'})
 
     charging = any(data['Amps'] > 0.)
     discharging = any(data['Amps'] < 0.)
 
-    if charging and discharging:
-        raise ValueError(
-            "'data' should not include both charge and discharge segments."
-        )
+    _check_only_one(
+        conditions=[charging, discharging],
+        message="'data' cannot include both charge and discharge segments.",
+    )
 
     df = data.copy()
     df = df.reset_index(drop=True)

--- a/src/ampworks/utils/_progress_bar.py
+++ b/src/ampworks/utils/_progress_bar.py
@@ -38,9 +38,7 @@ class ProgressBar(tqdm):
         Raises
         ------
         ValueError
-            'iterable' and 'manual' values are conflicting.
-        ValueError
-            'iterable' cannot be None if 'manual' is False.
+            Provide exactly one of 'iterable' or 'manual', not both.
 
         Examples
         --------
@@ -70,10 +68,12 @@ class ProgressBar(tqdm):
             progbar.close()
 
         """
-        if manual and iterable is not None:
-            raise ValueError("'iterable' and 'manual' values are conflicting.")
-        elif not manual and iterable is None:
-            raise ValueError("'iterable' cannot be None if 'manual' is False.")
+        from ampworks._checks import _check_only_one
+
+        _check_only_one(
+            conditions=[manual, iterable is not None],
+            message="Provide exactly one of 'iterable' or 'manual', not both.",
+        )
 
         kwargs.setdefault('desc', desc)
         kwargs.setdefault('ncols', ncols)

--- a/src/ampworks/utils/_rich_table.py
+++ b/src/ampworks/utils/_rich_table.py
@@ -109,9 +109,8 @@ class RichTable:
             If any columns listed in `_required_cols` are missing.
 
         """
-        required = set(cls._required_cols)
-        if not required.issubset(df.columns):
-            raise ValueError(f"Missing columns, {required=}.")
+        from ampworks._checks import _check_columns
+        _check_columns(df, set(cls._required_cols))
 
     @classmethod
     def from_csv(cls, path: str | Path) -> Self:

--- a/src/ampworks/utils/_timer.py
+++ b/src/ampworks/utils/_timer.py
@@ -72,9 +72,9 @@ class Timer:
             print(f"Elapsed time: {timer.elapsed_time:.5f} s")
 
         """
-        valid = ['s', 'min', 'h']
-        if units not in valid:
-            raise ValueError(f"{units=} is invalid; valid values are {valid}.")
+        from ampworks._checks import _check_literal
+
+        _check_literal('units', units, {'s', 'min', 'h'})
 
         self.name = name
         self._units = units

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1,0 +1,76 @@
+import pytest
+
+import ampworks as amp
+import ampworks._checks as checks
+
+
+def test_check_literal():
+
+    valid = {'a', 'b', None}
+    checks._check_literal('test', 'a', valid)
+    checks._check_literal('test', 'b', valid)
+    checks._check_literal('test', None, valid)
+
+    with pytest.raises(ValueError):
+        checks._check_literal('test', 'c', valid)
+
+
+def test_check_columns():
+
+    data = amp.Dataset({'col1': [1, 2], 'col2': [3, 4]})
+    checks._check_columns(data, ['col1'])
+    checks._check_columns(data, ['col2'])
+    checks._check_columns(data, ['col1', 'col2'])
+
+    with pytest.raises(ValueError):
+        checks._check_columns(data, ['col3'])
+
+    with pytest.raises(ValueError):
+        checks._check_columns(data, ['col1', 'col3'])
+
+
+def test_check_type():
+
+    checks._check_type('test', 1, int)
+    checks._check_type('test', 'a', str)
+    checks._check_type('test', None, None)
+    checks._check_type('test', None, type(None))
+    checks._check_type('test', 1.0, (int, float, None))
+
+    with pytest.raises(TypeError):
+        checks._check_type('test', 1, str)
+
+    with pytest.raises(TypeError):
+        checks._check_type('test', 'a', int)
+
+    with pytest.raises(TypeError):
+        checks._check_type('test', 1.0, int)
+
+
+def test_check_inner_type():
+
+    checks._check_inner_type('test', [1, 2], int)
+    checks._check_inner_type('test', ['a', 'b'], str)
+    checks._check_inner_type('test', [1.0, 2.0], (int, float))
+
+    with pytest.raises(TypeError):
+        checks._check_inner_type('test', [1, 'a'], int)
+
+    with pytest.raises(TypeError):
+        checks._check_inner_type('test', ['a', 1], str)
+
+    with pytest.raises(TypeError):
+        checks._check_inner_type('test', [1.0, 'a'], (int, float))
+
+
+def test_check_only_one():
+
+    checks._check_only_one([True, False, False], 'Pass.')
+    checks._check_only_one([False, True, False], 'Pass.')
+    checks._check_only_one([False, False, True], 'Pass.')
+
+    with pytest.raises(ValueError, match='Fail, two true.'):
+        checks._check_only_one([True, True, False], 'Fail, two true.')
+
+    with pytest.raises(ValueError, match='Fail, none true.'):
+        checks._check_only_one([False, False, False], 'Fail, none true.')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -80,10 +80,10 @@ def test_alphanum_sort():
 
 def test_progbar_initialization():
 
-    with pytest.raises(ValueError, match='conflicting'):
+    with pytest.raises(ValueError, match='Provide exactly one'):
         _ = amp.utils.ProgressBar(iterable=[1, 2, 3], manual=True)
 
-    with pytest.raises(ValueError, match='cannot be None'):
+    with pytest.raises(ValueError, match='Provide exactly one'):
         _ = amp.utils.ProgressBar(iterable=None, manual=False)
 
     bar = amp.utils.ProgressBar(iterable=[1, 2, 3])


### PR DESCRIPTION
# Description
There are many places in the code where it makes sense to check types of verify required columns are provided for particular routines. Instead of having duplicate code everywhere to raise these errors, there is now a new `_checks` module. This is not intended to be exposed to the user and thus is not imported into the main `__init__`. Rather, the checks are imported in functions locally where they are needed. Presently, there are checks to do the following:

1) Check types
2) Check inner types of sequences
3) Check a `Dataset` for required columns
4) Check that exactly one of a set of conditions is `True` to avoid conflicting settings/options
5) Check that a literal option exists within a valid set of options

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that improves speed/readability/etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (any other clean up, maintenance, etc.)

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.