### PR TITLE
tool.coverage in pyproject.toml; hidden funcs/methods all at end of class/file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ None.
 - Extra tabs in some `.txt` files were creating read errors, now ignore ragged columns ([#31](https://github.com/NatLabRockies/ampworks/pull/31))
 
 ### Chores
+- Move all hidden methods and functions to end of classes and files for consistency ([#33](https://github.com/NatLabRockies/ampworks/pull/33))
+- Add `tool.coverage` to `pyproject.toml` for excluding common statements ([#33](https://github.com/NatLabRockies/ampworks/pull/33))
 - Use base class `_RangeLabel` for both cycle and section labels ([#29](https://github.com/NatLabRockies/ampworks/pull/29))
 
 ## [v0.1.0](https://github.com/NatLabRockies/ampworks/tree/v0.1.0)

--- a/docs/source/development/patterns_and_conventions.rst
+++ b/docs/source/development/patterns_and_conventions.rst
@@ -15,7 +15,10 @@ To ensure consistency and ease of development, the following conventions are enf
     All file names begin with a leading underscore (`_`) to prevent them from showing up in an editor's tab completion window. File names also use snake case (e.g., `_my_class.py`) and are generally short but descriptive. Typically, the name of the file should reflect the class or function it contains.
 
 2. Class and function names: 
-    Classes use `CamelCase`, while functions and methods use `snake_case`. Classes should generally be in their own file unless grouped logically with others.
+    Classes use `PascalCase`. Functions, methods, and variables use `snake_case`. Classes should generally be in their own file unless grouped logically with others. Use preceding `_` for hidden/internal classes, functions, variables, etc.
+
+3. Constants: 
+    Constants are defined at the top of a file and use `UPPERCASE_SNAKE_CASE`. This makes them easily identifiable and accessible for users.
 
 Import Considerations
 ---------------------
@@ -57,8 +60,8 @@ For class definitions, we follow a specific ordering convention to make it easie
 
 1. **Magic Methods:** These special methods (e.g., `__init__`, `__repr__`, etc.) come first. They define key behaviors of the class.
 2. **Special Members:** Any properties, class methods, static methods, etc. Essentially, any decorated and/or "special" methods.
-3. **Hidden Methods:** These are internal methods (denoted with a leading underscore) that handle functionality not meant to be directly accessed by users.
-4. **User-Facing Methods:** These are the public methods intended for external use. They define the class's core functionality for users.
+3. **User-Facing Methods:** These are the public methods intended for external use. They define the class's core functionality for users.
+4. **Hidden Methods:** These are internal methods (denoted with a leading underscore) that handle functionality not meant to be directly accessed by users.
 
 In some cases, exceptions to this order may be made, particularly if moving a hidden method closer to a user-facing method improves readability. However, this should be done with discretion and only when it helps clarify the flow of the class's logic. See below for an example.
 
@@ -66,34 +69,35 @@ In some cases, exceptions to this order may be made, particularly if moving a hi
 
     class MyClass:
         # Magic Methods
-        def __init__(self, value):
+        def __init__(self, value: int) -> None:
             self._value = value
         
-        def __repr__(self):
+        def __repr__(self) -> str:
             return f"MyClass(value={self.value})"
 
         # Special Members
         @property
-        def value(self):
+        def value(self) -> int:
             return self._value
+        
+        # User-Facing Methods
+        def do_something(self) -> str:
+            self._helper_function()
+            return f"Value is {self.value}"
         
         # Hidden Methods
         def _helper_function(self):
             # Some internal logic
             pass
-        
-        # User-Facing Methods
-        def do_something(self):
-            self._helper_function()
-            return f"Value is {self.value}"
 
 Module Considerations
 ---------------------
 In our modules, we maintain a consistent structure to enhance readability and organization. The general order is as follows:
 
-1. **Classes:** If a module contains any class definitions, they should appear first. Classes define the core structure and behavior of the module.
-2. **Functions:** Public functions follow the class definitions. These functions are the primary operations or utilities that the module offers for external use.
-3. **Hidden Functions:** Internal functions (those with a leading underscore) come last. These are used for supporting internal logic and are not intended to be accessed directly by users.
+1. **Constants:** Any module-level constants or configuration variables should be defined at the top. This makes it easy for users to find and modify them if needed.
+2. **Classes:** If a module contains any class definitions, they should appear first. Classes define the core structure and behavior of the module.
+3. **Functions:** Public functions follow the class definitions. These functions are the primary operations or utilities that the module offers for external use.
+4. **Hidden Functions:** Internal functions (those with a leading underscore) come last. These are used for supporting internal logic and are not intended to be accessed directly by users.
 
 This ordering helps ensure that users interacting with the module can quickly identify the main components, while hidden/internal logic remains at the bottom for a clearer separation of concerns.
 

--- a/docs/source/development/tests_and_coverage.rst
+++ b/docs/source/development/tests_and_coverage.rst
@@ -11,8 +11,11 @@ Testing Practices
 * Test organization
     Tests should be organized first by module and then by class and/or function. This helps in managing and locating tests effectively. Avoid grouping tests into a single file just because they share similar functions. Instead, organize them based on their associated modules.
 
-* Naming conventions
-    All test functions should start with `test_` followed by a descriptive name (using snake case) indicating what is being tested. For example, `test_calculate_total_price` is preferable to `test_Calculator` unless the class is simple enough to be covered with a single test. Design tests to cover specific units, features, or applications of the class or function. 
+* Testing with functions
+    All test functions should start with `test_` followed by a descriptive name (using snake case) indicating what is being tested. For example, `test_calculate_total_price` is preferable to `test_Calculator` unless the class is simple enough to be covered with a single test. Design tests to cover specific units, features, or applications of the class or function.
+
+* Testing with classes
+    When using classes for testing, the class name should start with `Test` followed by the name of the class or function being tested (using Pascal case, e.g., `TestCalculator`). In these cases it is okay to be less descriptive with the class name, as the test functions (methods of the class) will provide the necessary context and should follow the same rules as testing with functions. Additionally, it is recommended to break up validation and functional tests into separate classes like `TestCalculatorValidation` and `TestCalculatorFunctional` to keep tests organized and focused. Validation tests should focus on catching warnings and errors, while functional tests should focus on the expected behavior of the class or function.
 
 * Test data
     Use fixtures where appropriate. If mock data is necessary, make a subfolder in the `tests/` to store it in. Make sure the file(s) have descriptive names. Ensure that test data is manageable and not overly complex.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,6 +90,12 @@ convention = "numpy"
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*" = ["D"]
 
+[tool.coverage.report]
+exclude_also = [
+    "def __repr__",
+    "if TYPE_CHECKING",
+]
+
 [project.optional-dependencies]
 gui = [
     "dash",

--- a/src/ampworks/__init__.py
+++ b/src/ampworks/__init__.py
@@ -72,7 +72,7 @@ __all__ = [
     '_in_interactive',
 ]
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from ampworks import (
         ocv, ici, gitt, dqdv, hppc, utils, labels, datasets, mathutils,
         plotutils,

--- a/src/ampworks/_auxiliary.py
+++ b/src/ampworks/_auxiliary.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 from scipy.integrate import cumulative_trapezoid
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     import ampworks as amp
 
 __all__ = [

--- a/src/ampworks/_checks.py
+++ b/src/ampworks/_checks.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from ampworks import Dataset
     from typing import Any, Set, Sequence, Type
 

--- a/src/ampworks/_core/_headers.py
+++ b/src/ampworks/_core/_headers.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Set, Dict, Sequence, Callable
 
 import pandas as pd
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from ampworks import Dataset
 
 AliasSet = Set[str] | Sequence[str]
@@ -268,7 +268,7 @@ class HeaderAliases:
             return getattr(self, key)
         raise KeyError(f"{key} not found in {type(self).__name__}")
 
-    def __repr__(self) -> str:  # pragma: no cover
+    def __repr__(self) -> str:
         data = {k: self[k] for k in self.keys()}
         summary = "\n".join([f"{k}={v!r}," for k, v in data.items()])
         summary = textwrap.indent(summary, " " * 4)

--- a/src/ampworks/_core/_read.py
+++ b/src/ampworks/_core/_read.py
@@ -8,78 +8,9 @@ from typing import TYPE_CHECKING, Sequence
 import pandas as pd
 import polars as pl
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from os import PathLike
     from ampworks import Dataset, HeaderAliases
-
-
-def _read_delimited(
-    filepath: PathLike,
-    delimiter: str,
-    aliases: HeaderAliases,
-    extra_columns: dict[str, type | None] | None,
-) -> Dataset:
-    r"""
-    Generic internal reader for delimited files. Used for shared logic between
-    the csv and txt readers.
-
-    Parameters
-    ----------
-    filepath : PathLike
-        Path to the file, including extension.
-    delimiter : str
-        Delimiter to use for parsing the file. For example, `','` for csv files
-        and `'\t'` for tab-delimited files.
-    aliases : HeaderAliases or None, optional
-        Column alias mapping for the header standardization. If None (default),
-        a set of internal default aliases is used.
-    extra_columns : dict[str, type or None] or None, optional
-        Additional columns to include in the standardized dataset. Include both
-        the exact source column names and their corresponding data types in a
-        dictionary. Use value None to keep pandas-inferred dtype. The `type` is
-        also compatible with pandas dtypes, e.g., `'string'`, `'Int64'`, etc.
-
-    Returns
-    -------
-    data : Dataset
-        Standardized battery dataset.
-
-    """
-    from ampworks import Dataset, HeaderAliases
-    from ampworks._checks import _check_type
-    from ampworks._core._headers import (
-        standardize_headers, header_matches, REQUIRED_HEADERS,
-    )
-
-    if aliases is None:
-        aliases = HeaderAliases()
-
-    _check_type('aliases', aliases, HeaderAliases)
-
-    options = {
-        'ignore_errors': True,
-        'separator': delimiter,
-        'truncate_ragged_lines': True,
-    }
-
-    skip_rows = None
-    with open(filepath, encoding='latin1') as datafile:
-        reader = csv.reader(datafile, delimiter=delimiter)
-
-        for idx, line in enumerate(reader):
-            if header_matches(line, REQUIRED_HEADERS, aliases):
-                skip_rows = idx
-                break
-
-    if skip_rows is not None:
-        options['skip_rows'] = skip_rows
-        df = pl.read_csv(filepath, **options).to_pandas()
-        return standardize_headers(df, aliases, extra_columns)
-
-    warn(f"No valid aliases found for {REQUIRED_HEADERS} in {filepath}."
-         " Returning empty dataset.")
-
-    return Dataset()
 
 
 def read_csv(
@@ -414,3 +345,72 @@ def read_excel(
         return single
 
     return datasets
+
+
+def _read_delimited(
+    filepath: PathLike,
+    delimiter: str,
+    aliases: HeaderAliases,
+    extra_columns: dict[str, type | None] | None,
+) -> Dataset:
+    r"""
+    Generic internal reader for delimited files. Used for shared logic between
+    the csv and txt readers.
+
+    Parameters
+    ----------
+    filepath : PathLike
+        Path to the file, including extension.
+    delimiter : str
+        Delimiter to use for parsing the file. For example, `','` for csv files
+        and `'\t'` for tab-delimited files.
+    aliases : HeaderAliases or None, optional
+        Column alias mapping for the header standardization. If None (default),
+        a set of internal default aliases is used.
+    extra_columns : dict[str, type or None] or None, optional
+        Additional columns to include in the standardized dataset. Include both
+        the exact source column names and their corresponding data types in a
+        dictionary. Use value None to keep pandas-inferred dtype. The `type` is
+        also compatible with pandas dtypes, e.g., `'string'`, `'Int64'`, etc.
+
+    Returns
+    -------
+    data : Dataset
+        Standardized battery dataset.
+
+    """
+    from ampworks import Dataset, HeaderAliases
+    from ampworks._checks import _check_type
+    from ampworks._core._headers import (
+        standardize_headers, header_matches, REQUIRED_HEADERS,
+    )
+
+    if aliases is None:
+        aliases = HeaderAliases()
+
+    _check_type('aliases', aliases, HeaderAliases)
+
+    options = {
+        'ignore_errors': True,
+        'separator': delimiter,
+        'truncate_ragged_lines': True,
+    }
+
+    skip_rows = None
+    with open(filepath, encoding='latin1') as datafile:
+        reader = csv.reader(datafile, delimiter=delimiter)
+
+        for idx, line in enumerate(reader):
+            if header_matches(line, REQUIRED_HEADERS, aliases):
+                skip_rows = idx
+                break
+
+    if skip_rows is not None:
+        options['skip_rows'] = skip_rows
+        df = pl.read_csv(filepath, **options).to_pandas()
+        return standardize_headers(df, aliases, extra_columns)
+
+    warn(f"No valid aliases found for {REQUIRED_HEADERS} in {filepath}."
+         " Returning empty dataset.")
+
+    return Dataset()

--- a/src/ampworks/datasets/__init__.py
+++ b/src/ampworks/datasets/__init__.py
@@ -44,7 +44,7 @@ import os
 import shutil
 import pathlib
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from ampworks import Dataset
 
 __all__ = [

--- a/src/ampworks/dqdv/_dqdv_fitter.py
+++ b/src/ampworks/dqdv/_dqdv_fitter.py
@@ -11,7 +11,7 @@ import scipy.optimize as opt
 import matplotlib.pyplot as plt
 import scipy.interpolate as interp
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     import numpy.typing as npt
 
     from ampworks.utils import RichResult
@@ -177,144 +177,6 @@ class DqdvFitter:
                              f" can only be 'all' or a subset of {options}.")
 
         self._cost_terms = list(set(value))  # ensure no duplicates
-
-    def _check_dataframe(self, df: pd.DataFrame, which: str) -> pd.DataFrame:
-        """
-        Verify that input dataframes have 'SOC' and 'Volts' columns. The full
-        cell dataset also requires an 'Ah' column.
-
-        Parameters
-        ----------
-        df : pd.DataFrame
-            Data to check for required columns.
-        which : {'neg', 'pos', 'cell'}
-            Which splines to build. Used to track initialization.
-
-        Returns
-        -------
-        df : None or pd.DataFrame
-            None if dataset has not yet been initialized. Otherwise, pass the
-            error checks and return the input DataFrame.
-
-        Raises
-        ------
-        TypeError
-            The 'df' input must be type pd.DataFrame.
-        ValueError
-            'df' is missing columns, required={'SOC', 'Volts'} for electrode
-            datasets and {'Ah', 'SOC', 'Volts'} for full cell datasets.
-
-        """
-        self._initialized[which] = False
-
-        required = {'SOC', 'Volts'}
-        if which == 'cell':
-            required.add('Ah')
-
-        if df is None:
-            pass
-        elif not isinstance(df, pd.DataFrame):
-            raise TypeError(f"'{which}' must be type pd.DataFrame.")
-        elif not required.issubset(df.columns):
-            raise ValueError(f"'{which}' is missing columns, {required=}.")
-
-        return df
-
-    def _build_splines(self, df: pd.DataFrame, which: str) -> Callable:
-        """
-        Generate OCV interpolation functions.
-
-        Parameters
-        ----------
-        df : pd.DataFrame
-            Data with 'SOC' and 'Volts' columns.
-        which : {'neg', 'pos', 'cell'}
-            Which splines to build. Used to track initialization.
-
-        Returns
-        -------
-        ocv, dvdq : tuple[Callable]
-            Spline interpolations for ocv and dvdq.
-
-        """
-        if df is None:
-            return None, None
-
-        _, mask = np.unique(df.SOC, return_index=True)
-
-        df = df.iloc[mask].reset_index(drop=True)
-        df = df.sort_values('SOC').reset_index(drop=True)
-
-        # make sure neg has decreasing voltage with increasing SOC and pos/cell
-        # have increasing so all splines are in reference to full-cell SOC.
-        flip_soc = {
-            'neg': lambda v0, v1: v0 < v1,
-            'pos': lambda v0, v1: v0 > v1,
-            'cell': lambda v0, v1: v0 > v1,
-        }
-
-        v0, v1 = df.Volts.iloc[0], df.Volts.iloc[-1]
-
-        if flip_soc[which](v0, v1):
-            df['SOC'] = 1.0 - df['SOC']
-
-        df = df.sort_values('SOC').reset_index(drop=True)
-
-        # build splines
-        ocv = interp.make_splrep(df.SOC, df.Volts)
-        dvdq = ocv.derivative()
-
-        self._initialized[which] = True
-
-        return ocv, dvdq
-
-    def _check_initialized(self, func_name: str) -> None:
-        """
-        Check that the instance is fully initialized, will all splines and
-        data for 'neg', 'pos', and 'cell'. If any is missing raise an error.
-
-        Parameters
-        ----------
-        func_name : str
-            Name of function performing check.
-
-        Raises
-        ------
-        RuntimeError
-            Can't run any functions until all data is available.
-
-        """
-        missing = [d for d, flag in self._initialized.items() if not flag]
-        if missing:
-            raise RuntimeError(f"Can't run '{func_name}' until all data is"
-                               f" available. Missing {missing} data.")
-
-    def _err_func(self, params: npt.ArrayLike) -> float:
-        """
-        The cost function for 'grid_search' and 'constrained_fit'.
-
-        Parameters
-        ----------
-        params : ArrayLike, shape(n,)
-            Array for xn0, xn1, xp0, xp1, and optionally iR.
-
-        Returns
-        -------
-        err_total : float
-            Total error based on a combination of cost_terms.
-
-        """
-        errs = self.err_terms(params)
-
-        err_total = 0.  # faster when MAPE is fractional, so use (*1e-2) below
-        if 'voltage' in self.cost_terms:
-            err_total += errs['volt_err']*1e-2
-        if 'dqdv' in self.cost_terms:
-            err_total += errs['dqdv_err']*1e-2
-        if 'dvdq' in self.cost_terms:
-            err_total += errs['dvdq_err']*1e-2
-
-        return err_total
 
     def get_ocv(self, which: str, soc: npt.ArrayLike) -> npt.ArrayLike:
         """
@@ -877,3 +739,141 @@ class DqdvFitter:
 
         if return_axs:
             return [ax1, twin, ax2, ax3]
+
+    def _check_dataframe(self, df: pd.DataFrame, which: str) -> pd.DataFrame:
+        """
+        Verify that input dataframes have 'SOC' and 'Volts' columns. The full
+        cell dataset also requires an 'Ah' column.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Data to check for required columns.
+        which : {'neg', 'pos', 'cell'}
+            Which splines to build. Used to track initialization.
+
+        Returns
+        -------
+        df : None or pd.DataFrame
+            None if dataset has not yet been initialized. Otherwise, pass the
+            error checks and return the input DataFrame.
+
+        Raises
+        ------
+        TypeError
+            The 'df' input must be type pd.DataFrame.
+        ValueError
+            'df' is missing columns, required={'SOC', 'Volts'} for electrode
+            datasets and {'Ah', 'SOC', 'Volts'} for full cell datasets.
+
+        """
+        self._initialized[which] = False
+
+        required = {'SOC', 'Volts'}
+        if which == 'cell':
+            required.add('Ah')
+
+        if df is None:
+            pass
+        elif not isinstance(df, pd.DataFrame):
+            raise TypeError(f"'{which}' must be type pd.DataFrame.")
+        elif not required.issubset(df.columns):
+            raise ValueError(f"'{which}' is missing columns, {required=}.")
+
+        return df
+
+    def _build_splines(self, df: pd.DataFrame, which: str) -> Callable:
+        """
+        Generate OCV interpolation functions.
+
+        Parameters
+        ----------
+        df : pd.DataFrame
+            Data with 'SOC' and 'Volts' columns.
+        which : {'neg', 'pos', 'cell'}
+            Which splines to build. Used to track initialization.
+
+        Returns
+        -------
+        ocv, dvdq : tuple[Callable]
+            Spline interpolations for ocv and dvdq.
+
+        """
+        if df is None:
+            return None, None
+
+        _, mask = np.unique(df.SOC, return_index=True)
+
+        df = df.iloc[mask].reset_index(drop=True)
+        df = df.sort_values('SOC').reset_index(drop=True)
+
+        # make sure neg has decreasing voltage with increasing SOC and pos/cell
+        # have increasing so all splines are in reference to full-cell SOC.
+        flip_soc = {
+            'neg': lambda v0, v1: v0 < v1,
+            'pos': lambda v0, v1: v0 > v1,
+            'cell': lambda v0, v1: v0 > v1,
+        }
+
+        v0, v1 = df.Volts.iloc[0], df.Volts.iloc[-1]
+
+        if flip_soc[which](v0, v1):
+            df['SOC'] = 1.0 - df['SOC']
+
+        df = df.sort_values('SOC').reset_index(drop=True)
+
+        # build splines
+        ocv = interp.make_splrep(df.SOC, df.Volts)
+        dvdq = ocv.derivative()
+
+        self._initialized[which] = True
+
+        return ocv, dvdq
+
+    def _check_initialized(self, func_name: str) -> None:
+        """
+        Check that the instance is fully initialized, will all splines and
+        data for 'neg', 'pos', and 'cell'. If any is missing raise an error.
+
+        Parameters
+        ----------
+        func_name : str
+            Name of function performing check.
+
+        Raises
+        ------
+        RuntimeError
+            Can't run any functions until all data is available.
+
+        """
+        missing = [d for d, flag in self._initialized.items() if not flag]
+        if missing:
+            raise RuntimeError(f"Can't run '{func_name}' until all data is"
+                               f" available. Missing {missing} data.")
+
+    def _err_func(self, params: npt.ArrayLike) -> float:
+        """
+        The cost function for 'grid_search' and 'constrained_fit'.
+
+        Parameters
+        ----------
+        params : ArrayLike, shape(n,)
+            Array for xn0, xn1, xp0, xp1, and optionally iR.
+
+        Returns
+        -------
+        err_total : float
+            Total error based on a combination of cost_terms.
+
+        """
+        errs = self.err_terms(params)
+
+        err_total = 0.  # faster when MAPE is fractional, so use (*1e-2) below
+        if 'voltage' in self.cost_terms:
+            err_total += errs['volt_err']*1e-2
+        if 'dqdv' in self.cost_terms:
+            err_total += errs['dqdv_err']*1e-2
+        if 'dvdq' in self.cost_terms:
+            err_total += errs['dvdq_err']*1e-2
+
+        return err_total

--- a/src/ampworks/dqdv/_dqdv_spline.py
+++ b/src/ampworks/dqdv/_dqdv_spline.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 from scipy.interpolate import make_splrep
 from scipy.integrate import cumulative_trapezoid
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from typing import Self
     import ampworks as amp
     import numpy.typing as npt

--- a/src/ampworks/dqdv/_lam_lli.py
+++ b/src/ampworks/dqdv/_lam_lli.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from ._tables import DegModeTable, DqdvFitTable
 
 

--- a/src/ampworks/dqdv/_tables.py
+++ b/src/ampworks/dqdv/_tables.py
@@ -6,7 +6,7 @@ import pandas as pd
 
 from ampworks.utils import RichTable, RichResult
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from typing import Self
     from pathlib import Path
 

--- a/src/ampworks/gitt/_extract_params.py
+++ b/src/ampworks/gitt/_extract_params.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from scipy.stats import linregress
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from ampworks import Dataset
 
 

--- a/src/ampworks/hppc/_extract_impedance.py
+++ b/src/ampworks/hppc/_extract_impedance.py
@@ -11,225 +11,8 @@ import plotly.graph_objects as go
 from plotly.subplots import make_subplots
 from scipy.integrate import cumulative_trapezoid
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from ampworks import Dataset
-
-
-def _plot_pulses(data: Dataset, **fig_kw) -> None:
-    """
-    Plot voltage profile with detected pulses highlighted.
-
-    Parameters
-    ----------
-    data : Dataset
-        Input Dataset with 'Hours', 'Amps', 'Volts', 'DisPulse', 'ChgPulse',
-        and 'StepTime'columns. These can all be added using _detect_pulses().
-    **fig_kw : dict, optional
-        Additional keyword arguments to use when plotting. A full list of names,
-        types, descriptions, and defaults is given below.
-    figsize : (int, int) or None, optional
-        Figure size (width, height) in pixels. Set either dimension to None for
-        responsiveness. In Jupyter, only width can resize; height is fixed. The
-        default is (800, 500).
-    save : str or None, optional
-        Path to save the plot as HTML. If not in a Jupyter notebook and save is
-        None, a temporary file is still created and is opened in the browser.
-
-    """
-    from ampworks.plotutils._plotly import PLOTLY_TEMPLATE, _render_plotly
-
-    save = fig_kw.get('save', None)
-    figsize = fig_kw.get('figsize', (800, 500))
-
-    # Two-row subplot with shared x-axis
-    fig = make_subplots(
-        rows=2, cols=1, shared_xaxes=True,
-        row_heights=[0.3, 0.7], vertical_spacing=0.05,
-    )
-
-    # Detect appropriate units for current
-    max_current = data['Amps'].abs().max()
-    if max_current >= 1e-1:
-        ycol, yunits = 'Amps', 'A'
-    elif max_current >= 1e-4:
-        ycol, yunits = 'milliAmps', 'mA'
-        data[ycol] = data['Amps'] * 1e3
-    else:
-        ycol, yunits = 'microAmps', 'uA'
-        data[ycol] = data['Amps'] * 1e6
-
-    # Full current and voltage traces
-    current = px.line(data, x='Hours', y=ycol)
-    current.data[0].update(line_color='black')
-
-    voltage = px.line(data, x='Hours', y='Volts')
-    voltage.data[0].update(line_color='black')
-
-    fig.add_trace(current.data[0], row=1, col=1)
-    fig.add_trace(voltage.data[0], row=2, col=1)
-
-    fig.update_xaxes(title_text='Hours', row=2, col=1)
-    fig.update_yaxes(title_text=ycol, row=1, col=1)
-    fig.update_yaxes(title_text='Volts', row=2, col=1)
-
-    # Add shaded pulses and markers
-    for pulse, color in zip(['DisPulse', 'ChgPulse'], ['red', 'blue']):
-
-        for idx, g in data.groupby(pulse, dropna=True):
-            t0, t1 = g['Hours'].iloc[0], g['Hours'].iloc[-1]
-            i0, i1 = g[ycol].iloc[0], g[ycol].iloc[-1]
-            v0, v1 = g['Volts'].iloc[0], g['Volts'].iloc[-1]
-
-            trel0, trel1 = g['StepTime'].iloc[0], g['StepTime'].iloc[-1]
-
-            hover_amps = (
-                f"StepTime: %{{customdata:.3f}} s<br>"
-                f"Current: %{{y:.3f}} {yunits}"
-            )
-            hover_volts = (
-                "StepTime: %{customdata:.3f} s<br>"
-                "Voltage: %{y:.3f} V"
-            )
-            customdata = [trel0, trel1]
-
-            fig.add_vrect(
-                x0=t0, x1=t1,  row=1, col=1,
-                fillcolor=color, opacity=0.3, line_width=0,
-            )
-            fig.add_trace(go.Scatter(
-                x=[t0, t1], y=[i0, i1], name=pulse + f"{idx}",
-                mode='markers', marker=dict(color=color, size=8),
-                hovertemplate=hover_amps, customdata=customdata,
-            ), row=1, col=1)
-
-            fig.add_vrect(
-                x0=t0, x1=t1, row=2, col=1,
-                fillcolor=color, opacity=0.3, line_width=0,
-            )
-            fig.add_trace(go.Scatter(
-                x=[t0, t1], y=[v0, v1], name=pulse + f"{idx}",
-                mode='markers', marker=dict(color=color, size=8),
-                hovertemplate=hover_volts, customdata=customdata,
-            ), row=2, col=1)
-
-    # Adjust layout and styling; then save and display
-    fig.update_layout(template=PLOTLY_TEMPLATE, showlegend=False)
-    _render_plotly(fig=fig, figsize=figsize, save=save)
-
-
-def _detect_pulses(
-    data: Dataset,
-    tmin: float = 0.,
-    tmax: float = 20.,
-    steps: list[int] | None = None,
-    plot: bool = False,
-    **fig_kw,
-) -> Dataset:
-    """
-    Detect charge and discharge pulses in the input Dataset. Optionally plot
-    the voltage profile with detected pulses highlighted.
-
-    Parameters
-    ----------
-    data : Dataset
-        Input Dataset with 'Seconds', 'Volts', and 'Amps' columns.
-    tmin : float, optional
-        Minimum pulse duration in seconds, by default 0. Any non-rest segments
-        shorter than this will be ignored.
-    tmax : float, optional
-        Maximum pulse duration in seconds, by default 20. Any non-rest segments
-        longer than this will be ignored.
-    steps : list[int] or None, optional
-        Explicit list of step numbers associated with HPPC pulses. If None,
-        pulses are autodetected based on state transitions. Requires a 'Step'
-        column in 'data'. Defaults to None.
-    plot : bool, optional
-        Whether to plot the current and voltage profiles with detected pulses
-        highlighted, by default False.
-    **fig_kw : dict, optional
-        Additional keyword arguments to use when plotting. A full list of names,
-        types, descriptions, and defaults is given below.
-    figsize : (int, int) or None, optional
-        Figure size (width, height) in pixels. Set either dimension to None for
-        responsiveness. In Jupyter, only width can resize; height is fixed. The
-        default is (800, 500).
-    save : str or None, optional
-        Path to save the plot as HTML. If not in a Jupyter notebook and save is
-        None, a temporary file is still created and is opened in the browser.
-
-    Returns
-    -------
-    data : amp.Dataset
-        A copy of the input Dataset with additional columns: 'Hours', 'State',
-        'Ah', 'SOC', 'Segment', 'StepTime', 'DisPulse', 'ChgPulse'.
-
-    """
-    from ampworks._auxiliary import _infer_state
-
-    df = data.copy()
-    df = df.reset_index(drop=True)
-
-    df['Seconds'] -= df['Seconds'].min()
-    df['Hours'] = df['Seconds'] / 3600.
-
-    # Create State column
-    _infer_state(df)
-
-    # Add Ah and SOC columns
-    is_net_charge = df['Volts'].iloc[0] < df['Volts'].iloc[-1]
-    sign = +1 if is_net_charge else -1
-
-    df['Ah'] = cumulative_trapezoid(sign*df['Amps'], df['Hours'], initial=0.)
-
-    if is_net_charge:
-        df['SOC'] = df['Ah'] / df['Ah'].max()
-    else:
-        df['SOC'] = 1. - df['Ah'] / df['Ah'].max()
-
-    # Create 'Step' column to group by State and Step
-    shifted_state = df['State'].shift(fill_value=df['State'].iloc[0])
-    df['Segment'] = (df['State'] != shifted_state).cumsum()
-
-    groups = df.groupby(['State', 'Segment'])
-    df['StepTime'] = np.nan
-
-    # Loop over (State, Step) groups to locate charge/discharge pulses
-    df['DisPulse'] = pd.NA
-    df['ChgPulse'] = pd.NA
-
-    dis_count = 1
-    chg_count = 1
-
-    for (state, _), g in groups:
-
-        idx = g.index
-        if idx[0] != df.index[0]:
-            idx = np.hstack([idx[0] - 1, idx], dtype=int)
-
-        steptime = df.loc[idx, 'Seconds'] - df.loc[idx[0], 'Seconds']
-
-        before, after = idx[0], idx[-1] + 1
-        if (state == 'R') or (steptime.max() > tmax):
-            continue
-        elif any(df.loc[[before, after], 'State'] != 'R'):
-            continue
-        elif (steps is not None) and (g['Step'].unique()[0] not in steps):
-            continue
-
-        if (state == 'D') and (steptime.max() >= tmin):
-            df.loc[idx, 'StepTime'] = steptime
-            df.loc[idx, 'DisPulse'] = dis_count
-            dis_count += 1
-        elif (state == 'C') and (steptime.max() >= tmin):
-            df.loc[idx, 'StepTime'] = steptime
-            df.loc[idx, 'ChgPulse'] = chg_count
-            chg_count += 1
-
-    # Plot, if requested
-    if plot:
-        _plot_pulses(df, **fig_kw)
-
-    return df
 
 
 def extract_impedance(
@@ -453,3 +236,220 @@ def extract_impedance(
     impedance.rename(columns=rename, inplace=True)
 
     return impedance
+
+
+def _plot_pulses(data: Dataset, **fig_kw) -> None:
+    """
+    Plot voltage profile with detected pulses highlighted.
+
+    Parameters
+    ----------
+    data : Dataset
+        Input Dataset with 'Hours', 'Amps', 'Volts', 'DisPulse', 'ChgPulse',
+        and 'StepTime'columns. These can all be added using _detect_pulses().
+    **fig_kw : dict, optional
+        Additional keyword arguments to use when plotting. A full list of names,
+        types, descriptions, and defaults is given below.
+    figsize : (int, int) or None, optional
+        Figure size (width, height) in pixels. Set either dimension to None for
+        responsiveness. In Jupyter, only width can resize; height is fixed. The
+        default is (800, 500).
+    save : str or None, optional
+        Path to save the plot as HTML. If not in a Jupyter notebook and save is
+        None, a temporary file is still created and is opened in the browser.
+
+    """
+    from ampworks.plotutils._plotly import PLOTLY_TEMPLATE, _render_plotly
+
+    save = fig_kw.get('save', None)
+    figsize = fig_kw.get('figsize', (800, 500))
+
+    # Two-row subplot with shared x-axis
+    fig = make_subplots(
+        rows=2, cols=1, shared_xaxes=True,
+        row_heights=[0.3, 0.7], vertical_spacing=0.05,
+    )
+
+    # Detect appropriate units for current
+    max_current = data['Amps'].abs().max()
+    if max_current >= 1e-1:
+        ycol, yunits = 'Amps', 'A'
+    elif max_current >= 1e-4:
+        ycol, yunits = 'milliAmps', 'mA'
+        data[ycol] = data['Amps'] * 1e3
+    else:
+        ycol, yunits = 'microAmps', 'uA'
+        data[ycol] = data['Amps'] * 1e6
+
+    # Full current and voltage traces
+    current = px.line(data, x='Hours', y=ycol)
+    current.data[0].update(line_color='black')
+
+    voltage = px.line(data, x='Hours', y='Volts')
+    voltage.data[0].update(line_color='black')
+
+    fig.add_trace(current.data[0], row=1, col=1)
+    fig.add_trace(voltage.data[0], row=2, col=1)
+
+    fig.update_xaxes(title_text='Hours', row=2, col=1)
+    fig.update_yaxes(title_text=ycol, row=1, col=1)
+    fig.update_yaxes(title_text='Volts', row=2, col=1)
+
+    # Add shaded pulses and markers
+    for pulse, color in zip(['DisPulse', 'ChgPulse'], ['red', 'blue']):
+
+        for idx, g in data.groupby(pulse, dropna=True):
+            t0, t1 = g['Hours'].iloc[0], g['Hours'].iloc[-1]
+            i0, i1 = g[ycol].iloc[0], g[ycol].iloc[-1]
+            v0, v1 = g['Volts'].iloc[0], g['Volts'].iloc[-1]
+
+            trel0, trel1 = g['StepTime'].iloc[0], g['StepTime'].iloc[-1]
+
+            hover_amps = (
+                f"StepTime: %{{customdata:.3f}} s<br>"
+                f"Current: %{{y:.3f}} {yunits}"
+            )
+            hover_volts = (
+                "StepTime: %{customdata:.3f} s<br>"
+                "Voltage: %{y:.3f} V"
+            )
+            customdata = [trel0, trel1]
+
+            fig.add_vrect(
+                x0=t0, x1=t1,  row=1, col=1,
+                fillcolor=color, opacity=0.3, line_width=0,
+            )
+            fig.add_trace(go.Scatter(
+                x=[t0, t1], y=[i0, i1], name=pulse + f"{idx}",
+                mode='markers', marker=dict(color=color, size=8),
+                hovertemplate=hover_amps, customdata=customdata,
+            ), row=1, col=1)
+
+            fig.add_vrect(
+                x0=t0, x1=t1, row=2, col=1,
+                fillcolor=color, opacity=0.3, line_width=0,
+            )
+            fig.add_trace(go.Scatter(
+                x=[t0, t1], y=[v0, v1], name=pulse + f"{idx}",
+                mode='markers', marker=dict(color=color, size=8),
+                hovertemplate=hover_volts, customdata=customdata,
+            ), row=2, col=1)
+
+    # Adjust layout and styling; then save and display
+    fig.update_layout(template=PLOTLY_TEMPLATE, showlegend=False)
+    _render_plotly(fig=fig, figsize=figsize, save=save)
+
+
+def _detect_pulses(
+    data: Dataset,
+    tmin: float = 0.,
+    tmax: float = 20.,
+    steps: list[int] | None = None,
+    plot: bool = False,
+    **fig_kw,
+) -> Dataset:
+    """
+    Detect charge and discharge pulses in the input Dataset. Optionally plot
+    the voltage profile with detected pulses highlighted.
+
+    Parameters
+    ----------
+    data : Dataset
+        Input Dataset with 'Seconds', 'Volts', and 'Amps' columns.
+    tmin : float, optional
+        Minimum pulse duration in seconds, by default 0. Any non-rest segments
+        shorter than this will be ignored.
+    tmax : float, optional
+        Maximum pulse duration in seconds, by default 20. Any non-rest segments
+        longer than this will be ignored.
+    steps : list[int] or None, optional
+        Explicit list of step numbers associated with HPPC pulses. If None,
+        pulses are autodetected based on state transitions. Requires a 'Step'
+        column in 'data'. Defaults to None.
+    plot : bool, optional
+        Whether to plot the current and voltage profiles with detected pulses
+        highlighted, by default False.
+    **fig_kw : dict, optional
+        Additional keyword arguments to use when plotting. A full list of names,
+        types, descriptions, and defaults is given below.
+    figsize : (int, int) or None, optional
+        Figure size (width, height) in pixels. Set either dimension to None for
+        responsiveness. In Jupyter, only width can resize; height is fixed. The
+        default is (800, 500).
+    save : str or None, optional
+        Path to save the plot as HTML. If not in a Jupyter notebook and save is
+        None, a temporary file is still created and is opened in the browser.
+
+    Returns
+    -------
+    data : amp.Dataset
+        A copy of the input Dataset with additional columns: 'Hours', 'State',
+        'Ah', 'SOC', 'Segment', 'StepTime', 'DisPulse', 'ChgPulse'.
+
+    """
+    from ampworks._auxiliary import _infer_state
+
+    df = data.copy()
+    df = df.reset_index(drop=True)
+
+    df['Seconds'] -= df['Seconds'].min()
+    df['Hours'] = df['Seconds'] / 3600.
+
+    # Create State column
+    _infer_state(df)
+
+    # Add Ah and SOC columns
+    is_net_charge = df['Volts'].iloc[0] < df['Volts'].iloc[-1]
+    sign = +1 if is_net_charge else -1
+
+    df['Ah'] = cumulative_trapezoid(sign*df['Amps'], df['Hours'], initial=0.)
+
+    if is_net_charge:
+        df['SOC'] = df['Ah'] / df['Ah'].max()
+    else:
+        df['SOC'] = 1. - df['Ah'] / df['Ah'].max()
+
+    # Create 'Step' column to group by State and Step
+    shifted_state = df['State'].shift(fill_value=df['State'].iloc[0])
+    df['Segment'] = (df['State'] != shifted_state).cumsum()
+
+    groups = df.groupby(['State', 'Segment'])
+    df['StepTime'] = np.nan
+
+    # Loop over (State, Step) groups to locate charge/discharge pulses
+    df['DisPulse'] = pd.NA
+    df['ChgPulse'] = pd.NA
+
+    dis_count = 1
+    chg_count = 1
+
+    for (state, _), g in groups:
+
+        idx = g.index
+        if idx[0] != df.index[0]:
+            idx = np.hstack([idx[0] - 1, idx], dtype=int)
+
+        steptime = df.loc[idx, 'Seconds'] - df.loc[idx[0], 'Seconds']
+
+        before, after = idx[0], idx[-1] + 1
+        if (state == 'R') or (steptime.max() > tmax):
+            continue
+        elif any(df.loc[[before, after], 'State'] != 'R'):
+            continue
+        elif (steps is not None) and (g['Step'].unique()[0] not in steps):
+            continue
+
+        if (state == 'D') and (steptime.max() >= tmin):
+            df.loc[idx, 'StepTime'] = steptime
+            df.loc[idx, 'DisPulse'] = dis_count
+            dis_count += 1
+        elif (state == 'C') and (steptime.max() >= tmin):
+            df.loc[idx, 'StepTime'] = steptime
+            df.loc[idx, 'ChgPulse'] = chg_count
+            chg_count += 1
+
+    # Plot, if requested
+    if plot:
+        _plot_pulses(df, **fig_kw)
+
+    return df

--- a/src/ampworks/ici/_extract_params.py
+++ b/src/ampworks/ici/_extract_params.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from scipy.stats import linregress
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from ampworks import Dataset
 
 

--- a/src/ampworks/labels.py
+++ b/src/ampworks/labels.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from numbers import Integral
 from typing import Sequence, TYPE_CHECKING
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from ampworks import Dataset
 
 __all__ = [
@@ -114,7 +114,7 @@ class _RangeLabel:
         self.steps = steps
         self.cycles = cycles
 
-    def __repr__(self) -> str:  # pragma: no cover
+    def __repr__(self) -> str:
         classname = type(self).__name__
         if self.steps is not None:
             return f"{classname}(label={self.label!r}, steps={self.steps!r})"

--- a/src/ampworks/mathutils.py
+++ b/src/ampworks/mathutils.py
@@ -15,7 +15,7 @@ __all__ = [
     'aggregate_over_x',
 ]
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from ampworks import Dataset
 
 

--- a/src/ampworks/ocv/_match_peaks.py
+++ b/src/ampworks/ocv/_match_peaks.py
@@ -7,7 +7,7 @@ import numpy as np
 from scipy.optimize import minimize
 from scipy.integrate import cumulative_trapezoid
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from ampworks.dqdv import DqdvSpline
 
 

--- a/src/ampworks/plotutils/_bokeh.py
+++ b/src/ampworks/plotutils/_bokeh.py
@@ -7,7 +7,7 @@ from tempfile import NamedTemporaryFile
 from IPython.display import display, HTML
 from bokeh import io as bk_io, models as bk_m
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from bokeh.plotting import figure as BokehFigure
 
 __all__ = [

--- a/src/ampworks/plotutils/_colors.py
+++ b/src/ampworks/plotutils/_colors.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import matplotlib as mpl
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from numpy import ndarray
 
 

--- a/src/ampworks/plotutils/_limits.py
+++ b/src/ampworks/plotutils/_limits.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from numpy.typing import ArrayLike
 
 

--- a/src/ampworks/plotutils/_plotly.py
+++ b/src/ampworks/plotutils/_plotly.py
@@ -6,7 +6,7 @@ from tempfile import NamedTemporaryFile
 
 import plotly.graph_objects as go
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from plotly.graph_objs._figure import Figure as PlotlyFigure
 
 __all__ = [

--- a/src/ampworks/plotutils/_text.py
+++ b/src/ampworks/plotutils/_text.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
 

--- a/src/ampworks/plotutils/_ticks.py
+++ b/src/ampworks/plotutils/_ticks.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from numpy import atleast_1d
 from matplotlib.ticker import AutoMinorLocator
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from matplotlib.axes import Axes
 
 

--- a/src/ampworks/utils/_rich_result.py
+++ b/src/ampworks/utils/_rich_result.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from typing import Any, Self
 
 

--- a/src/ampworks/utils/_rich_table.py
+++ b/src/ampworks/utils/_rich_table.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from pathlib import Path
     from typing import Any, Self, Sequence
     from pandas import Series, DataFrame
@@ -67,7 +67,9 @@ class RichTable:
             table = CustomTable(df)  # valid, no errors raised
 
         """
-        self._validate_columns(df)
+        from ampworks._checks import _check_columns
+        _check_columns(df, set(self._required_cols))
+
         self._df = df.copy()
 
     def __getitem__(self, key: str | list[str]) -> Series | DataFrame:
@@ -92,25 +94,6 @@ class RichTable:
     def __repr__(self) -> str:
         """Return the string representation of the underlying DataFrame."""
         return repr(self._df)
-
-    @classmethod
-    def _validate_columns(cls, df: DataFrame) -> None:
-        """
-        Ensure that all required columns are present.
-
-        Parameters
-        ----------
-        df : pd.DataFrame
-            The input DataFrame to validate during initialization.
-
-        Raises
-        ------
-        ValueError
-            If any columns listed in `_required_cols` are missing.
-
-        """
-        from ampworks._checks import _check_columns
-        _check_columns(df, set(cls._required_cols))
 
     @classmethod
     def from_csv(cls, path: str | Path) -> Self:

--- a/src/ampworks/utils/_timer.py
+++ b/src/ampworks/utils/_timer.py
@@ -87,7 +87,7 @@ class Timer:
         self._stop = 0.
         self._display = display
 
-    def __repr__(self) -> str:  # pragma: no cover
+    def __repr__(self) -> str:
         """Quick representation of the timer showing name, time, and units."""
         elapsed = self._converter[self._units](self.elapsed_time)
         elapsed_string = f"{elapsed} {self._units}"


### PR DESCRIPTION
# Description
Instead of putting `# pragma: no cover` all over for consistent ignores, like for `TYPE_CHECKING` and `__repr__`, now these are all globally excluding using `tool.coverage` in the `pyproject.toml` file. There is no longer a need to specify this for these two cases.

The documentation originally suggested hidden methods in classes come before public methods, but hidden functions in a module are located at the end of files. For consistency, hidden methods and functions are always at the bottom of the respective classes/files instead of having opposite locations as before. This is also updated in the docs `Patterns and Conventions`. The documentation also now has preferences for when `TestClasses` are used for testing, in addition to the preferences for `test_functions`, which are still the same.

Note that this cleanup is in preparation for a large overhaul to the API, coming soon.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (back-end change that improves speed/readability/etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (any other clean up, maintenance, etc.)

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.