### PR TITLE
feature/columns-rates-sequencing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,6 @@ __pycache__/
 *.pyd
 *.pxi
 
-# VSCode
-.vscode/
-
 # Distribution / packaging
 .Python
 build/

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+  "recommendations": [
+    "ms-python.python",
+    "ms-toolsai.jupyter",
+    "charliermarsh.ruff",
+    "njpwerner.autodocstring",
+  ],
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,63 @@
+{
+    // 1. Lock autoDocstring to NumPy style
+    "autoDocstring.docstringFormat": "numpy",
+
+    // 2. Force Ruff as the only formatter and linter
+    "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff",
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.fixAll.ruff": "explicit",
+            "source.organizeImports.ruff": "never",
+        },
+    },
+
+    // 3. Configure notebook with same Ruff settings as other .py files
+    "notebook.editorOptionsCustomizations": {
+    "editor.tabSize": 4,
+    "editor.indentSize": 4,
+    "editor.insertSpaces": true
+    },
+    "notebook.formatOnSave.enabled": true,
+    "notebook.defaultFormatter": "charliermarsh.ruff",
+    "notebook.codeActionsOnSave": {
+        "notebook.source.fixAll": "explicit",
+        "notebook.source.organizeImports": "never",
+    },
+    "notebook.lineNumbers": "on",
+    "notebook.consolidatedRunButton": true,
+
+    // 4. Configure Ruff settings for consistency with pyproject.toml settings
+    "ruff.configuration": {
+        "line-length": 80,
+        "exclude": ["build", "docs", "images", "reports"],
+        "unsafe-fixes": true,
+        "format": {
+            "quote-style": "preserve",
+        },
+        "lint": {
+            "preview": true,
+            "select": [
+                "E", // All pycodestyle errors
+                "W", // All pycodestyle warnings
+                "F", // All pyflakes errors
+                "B", // All flake8-bugbear checks
+                "D"  // All pydocstyle checks
+            ],
+            "extend-select": [
+                "E302", "E305" // Expected blank lines (requires preview=true)
+            ],
+            "ignore": [
+                "B007", "B009", "B010", "B028", "B905",
+                "D1", "D203", "D205", "D212", "D400", "D401", "D415",
+                "E201", "E202", "E226", "E241", "E731",
+            ],
+            "pydocstyle": {
+                "convention": "numpy",
+            },
+            "per-file-ignores": {
+                "tests/**/*": ["D"],
+            },
+        },
+    },
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [Unreleased](https://github.com/NatLabRockies/ampworks)
 
 ### New Features
+- Add `add_power`, `add_c_rate`, `add_instance_nums`, and `add_relative_time` to the `columns` module ([#35](https://github.com/NatLabRockies/ampworks/pull/35))
 - Add new `columns` module and move toward new API with `add_*` functions ([#34](https://github.com/NatLabRockies/ampworks/pull/34))
 - Allow unit overrides to `HeaderAliases` to help ensure self-consistent standardizations ([#32](https://github.com/NatLabRockies/ampworks/pull/32))
 - New `interactive_plotly` and `interactive_bokeh` methods with `kind` line/scatter option ([#31](https://github.com/NatLabRockies/ampworks/pull/31))
@@ -13,6 +14,7 @@
 - `interactive_xy_plot` deprecated in favor of `interactive_plotly` ([#31](https://github.com/NatLabRockies/ampworks/pull/31))
 
 ### Optimizations
+- Vectorize `add_relative_time`, removing a per-group `.transform` callable ([#35](https://github.com/NatLabRockies/ampworks/pull/35))
 - Vectorize `add_state`, `_ah_wh`, and remove `.transform` from `_instance_nums` ([#34](https://github.com/NatLabRockies/ampworks/pull/34))
 - Move backend datasets for examples and tests to `.parquet` formats ([#34](https://github.com/NatLabRockies/ampworks/pull/34))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [Unreleased](https://github.com/NatLabRockies/ampworks)
 
 ### New Features
-- Add `add_power`, `add_c_rate`, `add_instance_nums`, and `add_relative_time` to the `columns` module ([#35](https://github.com/NatLabRockies/ampworks/pull/35))
+- Add `_rate` and `_sequencing` submodules to the `columns` for power, C-rate, etc ([#35](https://github.com/NatLabRockies/ampworks/pull/35))
 - Add new `columns` module and move toward new API with `add_*` functions ([#34](https://github.com/NatLabRockies/ampworks/pull/34))
 - Allow unit overrides to `HeaderAliases` to help ensure self-consistent standardizations ([#32](https://github.com/NatLabRockies/ampworks/pull/32))
 - New `interactive_plotly` and `interactive_bokeh` methods with `kind` line/scatter option ([#31](https://github.com/NatLabRockies/ampworks/pull/31))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,9 @@ where = ["src"]
 line-length = 80
 exclude = ["build", "docs", "images", "reports"]
 
+[tool.ruff.format]
+quote-style = "preserve"
+
 [tool.ruff.lint]
 preview = true
 select = [

--- a/src/ampworks/columns/__init__.py
+++ b/src/ampworks/columns/__init__.py
@@ -13,6 +13,14 @@ from ._labels import (
     add_state,
     add_control_mode,
 )
+from ._rates import (
+    add_power,
+    add_c_rate,
+)
+from ._sequencing import (
+    add_instance_nums,
+    add_relative_time,
+)
 
 __all__ = [
     'StepLabel',
@@ -21,4 +29,8 @@ __all__ = [
     'add_segment_labels',
     'add_state',
     'add_control_mode',
+    'add_power',
+    'add_c_rate',
+    'add_instance_nums',
+    'add_relative_time',
 ]

--- a/src/ampworks/columns/_rates.py
+++ b/src/ampworks/columns/_rates.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ampworks import _checks as _chk
+
+if TYPE_CHECKING:
+    from ampworks import Dataset
+
+
+def add_power(
+    data: Dataset,
+    *,
+    col_name: str = 'Watts',
+    amps_alias: str = 'Amps',
+    volts_alias: str = 'Volts',
+) -> Dataset:
+    """
+    Add a power column to a dataset.
+
+    Calculates power as current times voltage, preserving the input's sign
+    convention (e.g., negative during discharge if current is negative).
+
+    Parameters
+    ----------
+    data : Dataset
+        The input dataset.
+    col_name : str, optional
+        Name of the column to add, by default 'Watts'.
+    amps_alias : str, optional
+        Name of the column containing current in amps, by default 'Amps'.
+    volts_alias : str, optional
+        Name of the column containing voltage in volts, by default 'Volts'.
+
+    Returns
+    -------
+    ds : Dataset
+        A modified copy of the input data, with a power column.
+
+    Examples
+    --------
+    Below we add a power column to a dataset using default settings.
+
+    >>> data = amp.Dataset(...)
+    >>> ds = add_power(data)
+
+    """
+    _chk._check_columns(data, [amps_alias, volts_alias])
+
+    ds = data.copy()
+    ds[col_name] = ds[amps_alias] * ds[volts_alias]
+    return ds
+
+
+def add_c_rate(
+    data: Dataset,
+    *,
+    amps_1c: float,
+    col_name: str = 'CRate',
+    amps_alias: str = 'Amps',
+) -> Dataset:
+    """
+    Add a C-rate column to a dataset.
+
+    Calculates C-rate as current divided by the magnitude of the 1C current,
+    preserving the input's sign convention (e.g., negative during discharge if
+    current is negative).
+
+    Parameters
+    ----------
+    data : Dataset
+        The input dataset.
+    amps_1c : float
+        The 1C current, in amps, used to calculate C-rate.
+    col_name : str, optional
+        Name of the column to add, by default 'CRate'.
+    amps_alias : str, optional
+        Name of the column containing current in amps, by default 'Amps'.
+
+    Returns
+    -------
+    ds : Dataset
+        A modified copy of the input data, with a C-rate column.
+
+    Notes
+    -----
+    No unit conversion is performed; `amps_alias` and `amps_1c` just need to
+    share consistent units.
+
+    Examples
+    --------
+    Below we add a C-rate column to a dataset using default settings and a 1C
+    current of 1.0 A.
+
+    >>> data = amp.Dataset(...)
+    >>> ds = add_c_rate(data, amps_1c=1.0)
+
+    If your analysis requires a positive definition of C-rate, regardless of
+    the sign of the current, use `ds['CRate'].abs()` in your downstream
+    processing.
+
+    """
+    _chk._check_columns(data, [amps_alias])
+
+    ds = data.copy()
+    ds[col_name] = ds[amps_alias] / abs(amps_1c)
+    return ds

--- a/src/ampworks/columns/_rates.py
+++ b/src/ampworks/columns/_rates.py
@@ -82,11 +82,6 @@ def add_c_rate(
     ds : Dataset
         A modified copy of the input data, with a C-rate column.
 
-    Notes
-    -----
-    No unit conversion is performed; `amps_alias` and `amps_1c` just need to
-    share consistent units.
-
     Examples
     --------
     Below we add a C-rate column to a dataset using default settings and a 1C
@@ -96,8 +91,7 @@ def add_c_rate(
     >>> ds = add_c_rate(data, amps_1c=1.0)
 
     If your analysis requires a positive definition of C-rate, regardless of
-    the sign of the current, use `ds['CRate'].abs()` in your downstream
-    processing.
+    the sign of the current, use `ds['CRate'].abs()` in downstream processes.
 
     """
     _chk._check_columns(data, [amps_alias])

--- a/src/ampworks/columns/_sequencing.py
+++ b/src/ampworks/columns/_sequencing.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ampworks import _checks as _chk
+from ampworks.columns._backend import _instance_nums
+
+if TYPE_CHECKING:
+    from ampworks import Dataset
+
+
+def add_instance_nums(
+    data: Dataset,
+    *,
+    which: str = 'Step',
+    col_name: str = 'InstanceNum',
+    cycle_alias: str = 'Cycle',
+    cycle_resets: bool = True,
+    fast: bool = False,
+) -> Dataset:
+    """
+    Add an instance numbers column to a dataset.
+
+    Instance numbers uniquely identify repeated occurrences of a group. For
+    example, if a single HPPC cycle contains ten discharge pulses that all
+    share the same step number (e.g., 5), instance numbers label them 1
+    through 10. Numbering can reset every cycle or stay globally unique,
+    depending on `cycle_resets`. Numbering is 1-based, so the first instance
+    of a group is always 1, not 0.
+
+    Parameters
+    ----------
+    data : Dataset
+        The input dataset.
+    which : str, optional
+        The column used to detect and group instances, by default 'Step'.
+    col_name : str, optional
+        Name of the column to add, by default 'InstanceNum'.
+    cycle_alias : str, optional
+        Name of the column containing cycle numbers, by default 'Cycle'. Only
+        used if the `cycle_resets` argument is True.
+    cycle_resets : bool, optional
+        Whether the instance numbers reset at the start of each cycle. If True
+        (default), instance numbers are unique within each cycle, not globally.
+    fast : bool, optional
+        If True, returns the raw instance numbers, by default False. See the
+        notes section for more details.
+
+    Returns
+    -------
+    ds : Dataset
+        A modified copy of the input data, with an instance numbers column.
+
+    Raises
+    ------
+    ValueError
+        If `cycle_resets` is True and `cycle_alias` is None.
+
+    Warnings
+    --------
+    UserWarning
+        Cycle resets are ignored when `fast=True`, even if requested.
+
+    Notes
+    -----
+    With `fast=True`, cycle resets are ignored and the result is just a
+    monotonically increasing changeover counter, not a per-group occurrence
+    count. This is cheaper when you only need to detect a new instance, not
+    know it's specifically the first or Nth occurrence.
+
+    Examples
+    --------
+    Below we add an instance numbers column to a dataset using default
+    settings, then use it to analyze a repeated step (e.g., step 5).
+
+    >>> data = amp.Dataset(...)
+    >>> ds = add_instance_nums(data)
+    >>> step5 = ds[ds['Step'] == 5]
+    >>> groups = step5.groupby('InstanceNum')
+
+    Instance numbers also make it easy to pull metrics for just the first
+    occurrence of a repeated step within each cycle:
+
+    >>> first_means = step5[step5['InstanceNum'] == 1].groupby('Cycle').mean()
+
+    """
+    check_columns = [which, cycle_alias] if cycle_resets else [which]
+
+    _chk._check_columns(data, check_columns)
+
+    ds = data.copy()
+
+    ds[col_name] = _instance_nums(
+        data=ds,
+        which=which,
+        cycle_alias=cycle_alias,
+        cycle_resets=cycle_resets,
+        fast=fast,
+    )
+
+    return ds
+
+
+def add_relative_time(
+    data: Dataset,
+    *,
+    which: str = 'Step',
+    col_name: str = 'StepTime',
+    time_alias: str = 'Seconds',
+) -> Dataset:
+    """
+    Add a relative time column to a dataset.
+
+    Parameters
+    ----------
+    data : Dataset
+        The input dataset.
+    which : str, optional
+        The column used to define groups where relative time resets to zero.
+        Defaults to 'Step', resetting relative time at the start of each step.
+    col_name : str, optional
+        Name of the column to add, by default 'StepTime'.
+    time_alias : str, optional
+        Name of the column containing global time values, by default 'Seconds'.
+
+    Returns
+    -------
+    ds : Dataset
+        A modified copy of the input data, with a relative time column.
+
+    Examples
+    --------
+    Below we add a relative time column to a dataset using default settings.
+
+    >>> data = amp.Dataset(...)
+    >>> ds = add_relative_time(data)
+
+    You may want relative time to reset on changes in State instead of Step,
+    e.g., to get relative times for charge/discharge/rest segments that span
+    multiple steps (a CCCV charge, or a rest split across steps for varying
+    time resolution). Use a different `which` column to control this:
+
+    >>> ds = add_relative_time(data, which='State')
+
+    The time column also doesn't need to be in seconds. If you already have
+    another time column, use it via `time_alias`:
+
+    >>> ds['Hours'] = ds['Seconds'] / 3600.0
+    >>> ds = add_relative_time(data, time_alias='Hours')
+
+    """
+    _chk._check_columns(data, [which, time_alias])
+
+    ds = data.copy()
+
+    instance_nums = _instance_nums(
+        data=ds,
+        which=which,
+        cycle_alias=None,
+        cycle_resets=False,
+        fast=True,
+    )
+
+    groups = ds.groupby([which, instance_nums])[time_alias]
+    ds[col_name] = ds[time_alias] - groups.transform('first')
+
+    return ds

--- a/src/ampworks/columns/_sequencing.py
+++ b/src/ampworks/columns/_sequencing.py
@@ -23,10 +23,10 @@ def add_instance_nums(
 
     Instance numbers uniquely identify repeated occurrences of a group. For
     example, if a single HPPC cycle contains ten discharge pulses that all
-    share the same step number (e.g., 5), instance numbers label them 1
-    through 10. Numbering can reset every cycle or stay globally unique,
-    depending on `cycle_resets`. Numbering is 1-based, so the first instance
-    of a group is always 1, not 0.
+    share the same step number (e.g., 5), instance numbers label them 1 through
+    10. Numbering can reset every cycle or stay globally unique, depending on
+    `cycle_resets`. Numbering is 1-based, so the first instance of a group is
+    always 1, not 0.
 
     Parameters
     ----------
@@ -63,23 +63,24 @@ def add_instance_nums(
 
     Notes
     -----
-    With `fast=True`, cycle resets are ignored and the result is just a
-    monotonically increasing changeover counter, not a per-group occurrence
-    count. This is cheaper when you only need to detect a new instance, not
-    know it's specifically the first or Nth occurrence.
+    With `fast=True`, all group resets are ignored and result in a monotonically
+    increasing changeover counter, not a per-group occurrence count. This is
+    computationally cheaper when you only need to detect a new instance, and do
+    not care whether it's specifically the first or Nth occurrence.
 
     Examples
     --------
-    Below we add an instance numbers column to a dataset using default
-    settings, then use it to analyze a repeated step (e.g., step 5).
+    Below we add an instance numbers column to a dataset using default settings,
+    then use it to construct groups for downstream analysis on the instances of
+    step 5.
 
     >>> data = amp.Dataset(...)
     >>> ds = add_instance_nums(data)
     >>> step5 = ds[ds['Step'] == 5]
     >>> groups = step5.groupby('InstanceNum')
 
-    Instance numbers also make it easy to pull metrics for just the first
-    occurrence of a repeated step within each cycle:
+    Instance numbers can also make it easy to pull metrics/statistics for any
+    Nth occurrence of a repeated step within each cycle:
 
     >>> first_means = step5[step5['InstanceNum'] == 1].groupby('Cycle').mean()
 
@@ -137,13 +138,13 @@ def add_relative_time(
 
     You may want relative time to reset on changes in State instead of Step,
     e.g., to get relative times for charge/discharge/rest segments that span
-    multiple steps (a CCCV charge, or a rest split across steps for varying
-    time resolution). Use a different `which` column to control this:
+    multiple steps (e.g., a CCCV charge). Use a different `which` column to
+    control this:
 
     >>> ds = add_relative_time(data, which='State')
 
-    The time column also doesn't need to be in seconds. If you already have
-    another time column, use it via `time_alias`:
+    The time column also doesn't need to be in seconds. If you have another time
+    column, use it via `time_alias`:
 
     >>> ds['Hours'] = ds['Seconds'] / 3600.0
     >>> ds = add_relative_time(data, time_alias='Hours')

--- a/tests/test_columns/test_rates.py
+++ b/tests/test_columns/test_rates.py
@@ -2,8 +2,7 @@ import pytest
 import numpy.testing as npt
 
 import ampworks as amp
-
-from ampworks.columns import add_power, add_c_rate
+import ampworks.columns as col
 
 
 @pytest.fixture
@@ -13,33 +12,37 @@ def rates_data():
         'Amps': [1., -2., 0., 3.],
         'Volts': [4.0, 3.5, 4.2, 3.0],
         'ExpectedWatts': [4.0, -7.0, 0.0, 9.0],
-        'ExpectedCRate': [1., -2., 0., 3.],  # amps_1c = 1.0
+        'ExpectedCRate': [0.5, -1., 0., 1.5],  # amps_1c = 2.0
     })
 
 
 class TestAddPower:
 
     def test_missing_columns_raises(self, rates_data):
+        ds = rates_data.drop(columns=['Amps'])
+        with pytest.raises(ValueError):
+            col.add_power(ds)
+
         ds = rates_data.drop(columns=['Volts'])
         with pytest.raises(ValueError):
-            add_power(ds)
+            col.add_power(ds)
 
     def test_values(self, rates_data):
-        result = add_power(rates_data)
+        result = col.add_power(rates_data)
         npt.assert_allclose(result['Watts'], rates_data['ExpectedWatts'])
 
     def test_col_name(self, rates_data):
-        result = add_power(rates_data, col_name='Custom')
+        result = col.add_power(rates_data, col_name='Custom')
         assert 'Custom' in result.columns
         assert 'Watts' not in result.columns
 
     def test_aliases(self, rates_data):
         ds = rates_data.rename(columns={'Amps': 'Current', 'Volts': 'Voltage'})
-        result = add_power(ds, amps_alias='Current', volts_alias='Voltage')
+        result = col.add_power(ds, amps_alias='Current', volts_alias='Voltage')
         npt.assert_allclose(result['Watts'], rates_data['ExpectedWatts'])
 
     def test_returns_copy(self, rates_data):
-        result = add_power(rates_data)
+        result = col.add_power(rates_data)
         assert result is not rates_data
         assert 'Watts' not in rates_data.columns
 
@@ -49,28 +52,28 @@ class TestAddCRate:
     def test_missing_columns_raises(self, rates_data):
         ds = rates_data.drop(columns=['Amps'])
         with pytest.raises(ValueError):
-            add_c_rate(ds, amps_1c=1.0)
+            col.add_c_rate(ds, amps_1c=2.0)
 
     def test_values(self, rates_data):
-        result = add_c_rate(rates_data, amps_1c=1.0)
+        result = col.add_c_rate(rates_data, amps_1c=2.0)
         npt.assert_allclose(result['CRate'], rates_data['ExpectedCRate'])
 
     def test_amps_1c_uses_magnitude(self, rates_data):
         # sign of amps_1c shouldn't matter, only its magnitude
-        result = add_c_rate(rates_data, amps_1c=-1.0)
+        result = col.add_c_rate(rates_data, amps_1c=-2.0)
         npt.assert_allclose(result['CRate'], rates_data['ExpectedCRate'])
 
     def test_col_name(self, rates_data):
-        result = add_c_rate(rates_data, amps_1c=1.0, col_name='Custom')
+        result = col.add_c_rate(rates_data, amps_1c=2.0, col_name='Custom')
         assert 'Custom' in result.columns
         assert 'CRate' not in result.columns
 
     def test_amps_alias(self, rates_data):
         ds = rates_data.rename(columns={'Amps': 'Current'})
-        result = add_c_rate(ds, amps_1c=1.0, amps_alias='Current')
+        result = col.add_c_rate(ds, amps_1c=2.0, amps_alias='Current')
         npt.assert_allclose(result['CRate'], rates_data['ExpectedCRate'])
 
     def test_returns_copy(self, rates_data):
-        result = add_c_rate(rates_data, amps_1c=1.0)
+        result = col.add_c_rate(rates_data, amps_1c=2.0)
         assert result is not rates_data
         assert 'CRate' not in rates_data.columns

--- a/tests/test_columns/test_rates.py
+++ b/tests/test_columns/test_rates.py
@@ -1,0 +1,76 @@
+import pytest
+import numpy.testing as npt
+
+import ampworks as amp
+
+from ampworks.columns import add_power, add_c_rate
+
+
+@pytest.fixture
+def rates_data():
+    """Amps/Volts pairs with hand-computed Watts and CRate expectations."""
+    return amp.Dataset({
+        'Amps': [1., -2., 0., 3.],
+        'Volts': [4.0, 3.5, 4.2, 3.0],
+        'ExpectedWatts': [4.0, -7.0, 0.0, 9.0],
+        'ExpectedCRate': [1., -2., 0., 3.],  # amps_1c = 1.0
+    })
+
+
+class TestAddPower:
+
+    def test_missing_columns_raises(self, rates_data):
+        ds = rates_data.drop(columns=['Volts'])
+        with pytest.raises(ValueError):
+            add_power(ds)
+
+    def test_values(self, rates_data):
+        result = add_power(rates_data)
+        npt.assert_allclose(result['Watts'], rates_data['ExpectedWatts'])
+
+    def test_col_name(self, rates_data):
+        result = add_power(rates_data, col_name='Custom')
+        assert 'Custom' in result.columns
+        assert 'Watts' not in result.columns
+
+    def test_aliases(self, rates_data):
+        ds = rates_data.rename(columns={'Amps': 'Current', 'Volts': 'Voltage'})
+        result = add_power(ds, amps_alias='Current', volts_alias='Voltage')
+        npt.assert_allclose(result['Watts'], rates_data['ExpectedWatts'])
+
+    def test_returns_copy(self, rates_data):
+        result = add_power(rates_data)
+        assert result is not rates_data
+        assert 'Watts' not in rates_data.columns
+
+
+class TestAddCRate:
+
+    def test_missing_columns_raises(self, rates_data):
+        ds = rates_data.drop(columns=['Amps'])
+        with pytest.raises(ValueError):
+            add_c_rate(ds, amps_1c=1.0)
+
+    def test_values(self, rates_data):
+        result = add_c_rate(rates_data, amps_1c=1.0)
+        npt.assert_allclose(result['CRate'], rates_data['ExpectedCRate'])
+
+    def test_amps_1c_uses_magnitude(self, rates_data):
+        # sign of amps_1c shouldn't matter, only its magnitude
+        result = add_c_rate(rates_data, amps_1c=-1.0)
+        npt.assert_allclose(result['CRate'], rates_data['ExpectedCRate'])
+
+    def test_col_name(self, rates_data):
+        result = add_c_rate(rates_data, amps_1c=1.0, col_name='Custom')
+        assert 'Custom' in result.columns
+        assert 'CRate' not in result.columns
+
+    def test_amps_alias(self, rates_data):
+        ds = rates_data.rename(columns={'Amps': 'Current'})
+        result = add_c_rate(ds, amps_1c=1.0, amps_alias='Current')
+        npt.assert_allclose(result['CRate'], rates_data['ExpectedCRate'])
+
+    def test_returns_copy(self, rates_data):
+        result = add_c_rate(rates_data, amps_1c=1.0)
+        assert result is not rates_data
+        assert 'CRate' not in rates_data.columns

--- a/tests/test_columns/test_sequencing.py
+++ b/tests/test_columns/test_sequencing.py
@@ -2,15 +2,16 @@ import pytest
 import numpy.testing as npt
 
 import ampworks as amp
-
-from ampworks.columns import add_instance_nums, add_relative_time
+import ampworks.columns as col
 
 
 @pytest.fixture
 def sequencing_data():
-    """Step 1 repeats within Cycle 1, then again within Cycle 2. The Step
-    value itself doesn't change across the cycle boundary (rows 5-6), so
-    'fast' (Step-only) grouping merges what 'cycle_resets' keeps separate.
+    """
+    Step 1 repeats within Cycle 1, then again within Cycle 2. The Step value
+    itself doesn't change across the cycle boundary (rows 5-6), so 'fast'
+    (Step-only) grouping merges what 'cycle_resets' keeps separate.
+
     """
     return amp.Dataset({
         'Step': [1, 1, 2, 2, 1, 1, 1, 1, 2, 2, 1, 1],
@@ -26,40 +27,39 @@ class TestAddInstanceNums:
     def test_missing_step_column_raises(self, sequencing_data):
         ds = sequencing_data.drop(columns=['Step'])
         with pytest.raises(ValueError):
-            add_instance_nums(ds)
+            col.add_instance_nums(ds)
 
-    def test_missing_cycle_column_raises_when_cycle_resets(
-        self, sequencing_data,
-    ):
+    def test_missing_cycle_column_raises_with_resets(self, sequencing_data):
         ds = sequencing_data.drop(columns=['Cycle'])
         with pytest.raises(ValueError):
-            add_instance_nums(ds)
+            col.add_instance_nums(ds, cycle_resets=True)
 
     def test_default_settings(self, sequencing_data):
-        result = add_instance_nums(sequencing_data)
+        result = col.add_instance_nums(sequencing_data)
         npt.assert_array_equal(
-            result['InstanceNum'], sequencing_data['ExpectedInstanceNum'],
+            result['InstanceNum'],
+            sequencing_data['ExpectedInstanceNum'],
         )
 
     def test_cycle_resets_false_is_global(self, sequencing_data):
-        result = add_instance_nums(sequencing_data, cycle_resets=False)
+        result = col.add_instance_nums(sequencing_data, cycle_resets=False)
         expected = [1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3]
         npt.assert_array_equal(result['InstanceNum'], expected)
 
-    def test_fast_option_warns_and_ignores_cycle_resets(self, sequencing_data):
+    def test_fast_option_warns_and_ignores_resets(self, sequencing_data):
         with pytest.warns(UserWarning, match='fast=True'):
-            result = add_instance_nums(sequencing_data, fast=True)
+            result = col.add_instance_nums(sequencing_data, fast=True)
 
         expected = [1, 1, 2, 2, 3, 3, 3, 3, 4, 4, 5, 5]
         npt.assert_array_equal(result['InstanceNum'], expected)
 
     def test_col_name(self, sequencing_data):
-        result = add_instance_nums(sequencing_data, col_name='Custom')
+        result = col.add_instance_nums(sequencing_data, col_name='Custom')
         assert 'Custom' in result.columns
         assert 'InstanceNum' not in result.columns
 
     def test_returns_copy(self, sequencing_data):
-        result = add_instance_nums(sequencing_data)
+        result = col.add_instance_nums(sequencing_data)
         assert result is not sequencing_data
         assert 'InstanceNum' not in sequencing_data.columns
 
@@ -69,34 +69,37 @@ class TestAddRelativeTime:
     def test_missing_columns_raises(self, sequencing_data):
         ds = sequencing_data.drop(columns=['Seconds'])
         with pytest.raises(ValueError):
-            add_relative_time(ds)
+            col.add_relative_time(ds)
 
     def test_default_settings(self, sequencing_data):
-        result = add_relative_time(sequencing_data)
+        result = col.add_relative_time(sequencing_data)
         npt.assert_allclose(
-            result['StepTime'], sequencing_data['ExpectedStepTime'],
+            result['StepTime'],
+            sequencing_data['ExpectedStepTime'],
         )
 
     def test_which_alias(self, sequencing_data):
         ds = sequencing_data.rename(columns={'Step': 'Segment'})
-        result = add_relative_time(ds, which='Segment')
+        result = col.add_relative_time(ds, which='Segment')
         npt.assert_allclose(
-            result['StepTime'], sequencing_data['ExpectedStepTime'],
+            result['StepTime'],
+            sequencing_data['ExpectedStepTime'],
         )
 
     def test_time_alias(self, sequencing_data):
         ds = sequencing_data.rename(columns={'Seconds': 'Elapsed'})
-        result = add_relative_time(ds, time_alias='Elapsed')
+        result = col.add_relative_time(ds, time_alias='Elapsed')
         npt.assert_allclose(
-            result['StepTime'], sequencing_data['ExpectedStepTime'],
+            result['StepTime'],
+            sequencing_data['ExpectedStepTime'],
         )
 
     def test_col_name(self, sequencing_data):
-        result = add_relative_time(sequencing_data, col_name='Custom')
+        result = col.add_relative_time(sequencing_data, col_name='Custom')
         assert 'Custom' in result.columns
         assert 'StepTime' not in result.columns
 
     def test_returns_copy(self, sequencing_data):
-        result = add_relative_time(sequencing_data)
+        result = col.add_relative_time(sequencing_data)
         assert result is not sequencing_data
         assert 'StepTime' not in sequencing_data.columns

--- a/tests/test_columns/test_sequencing.py
+++ b/tests/test_columns/test_sequencing.py
@@ -1,0 +1,102 @@
+import pytest
+import numpy.testing as npt
+
+import ampworks as amp
+
+from ampworks.columns import add_instance_nums, add_relative_time
+
+
+@pytest.fixture
+def sequencing_data():
+    """Step 1 repeats within Cycle 1, then again within Cycle 2. The Step
+    value itself doesn't change across the cycle boundary (rows 5-6), so
+    'fast' (Step-only) grouping merges what 'cycle_resets' keeps separate.
+    """
+    return amp.Dataset({
+        'Step': [1, 1, 2, 2, 1, 1, 1, 1, 2, 2, 1, 1],
+        'Cycle': [1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2],
+        'Seconds': [0., 1., 2., 3., 4., 5., 6., 7., 8., 9., 10., 11.],
+        'ExpectedInstanceNum': [1, 1, 1, 1, 2, 2, 1, 1, 1, 1, 2, 2],
+        'ExpectedStepTime': [0., 1., 0., 1., 0., 1., 2., 3., 0., 1., 0., 1.],
+    })
+
+
+class TestAddInstanceNums:
+
+    def test_missing_step_column_raises(self, sequencing_data):
+        ds = sequencing_data.drop(columns=['Step'])
+        with pytest.raises(ValueError):
+            add_instance_nums(ds)
+
+    def test_missing_cycle_column_raises_when_cycle_resets(
+        self, sequencing_data,
+    ):
+        ds = sequencing_data.drop(columns=['Cycle'])
+        with pytest.raises(ValueError):
+            add_instance_nums(ds)
+
+    def test_default_settings(self, sequencing_data):
+        result = add_instance_nums(sequencing_data)
+        npt.assert_array_equal(
+            result['InstanceNum'], sequencing_data['ExpectedInstanceNum'],
+        )
+
+    def test_cycle_resets_false_is_global(self, sequencing_data):
+        result = add_instance_nums(sequencing_data, cycle_resets=False)
+        expected = [1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 3, 3]
+        npt.assert_array_equal(result['InstanceNum'], expected)
+
+    def test_fast_option_warns_and_ignores_cycle_resets(self, sequencing_data):
+        with pytest.warns(UserWarning, match='fast=True'):
+            result = add_instance_nums(sequencing_data, fast=True)
+
+        expected = [1, 1, 2, 2, 3, 3, 3, 3, 4, 4, 5, 5]
+        npt.assert_array_equal(result['InstanceNum'], expected)
+
+    def test_col_name(self, sequencing_data):
+        result = add_instance_nums(sequencing_data, col_name='Custom')
+        assert 'Custom' in result.columns
+        assert 'InstanceNum' not in result.columns
+
+    def test_returns_copy(self, sequencing_data):
+        result = add_instance_nums(sequencing_data)
+        assert result is not sequencing_data
+        assert 'InstanceNum' not in sequencing_data.columns
+
+
+class TestAddRelativeTime:
+
+    def test_missing_columns_raises(self, sequencing_data):
+        ds = sequencing_data.drop(columns=['Seconds'])
+        with pytest.raises(ValueError):
+            add_relative_time(ds)
+
+    def test_default_settings(self, sequencing_data):
+        result = add_relative_time(sequencing_data)
+        npt.assert_allclose(
+            result['StepTime'], sequencing_data['ExpectedStepTime'],
+        )
+
+    def test_which_alias(self, sequencing_data):
+        ds = sequencing_data.rename(columns={'Step': 'Segment'})
+        result = add_relative_time(ds, which='Segment')
+        npt.assert_allclose(
+            result['StepTime'], sequencing_data['ExpectedStepTime'],
+        )
+
+    def test_time_alias(self, sequencing_data):
+        ds = sequencing_data.rename(columns={'Seconds': 'Elapsed'})
+        result = add_relative_time(ds, time_alias='Elapsed')
+        npt.assert_allclose(
+            result['StepTime'], sequencing_data['ExpectedStepTime'],
+        )
+
+    def test_col_name(self, sequencing_data):
+        result = add_relative_time(sequencing_data, col_name='Custom')
+        assert 'Custom' in result.columns
+        assert 'StepTime' not in result.columns
+
+    def test_returns_copy(self, sequencing_data):
+        result = add_relative_time(sequencing_data)
+        assert result is not sequencing_data
+        assert 'StepTime' not in sequencing_data.columns


### PR DESCRIPTION
# Description
Continue adding to the new `columns` module. This PR includes `_rates` and `_sequencing` submodules with functions to add power, C-rate, relative time, and instance numbers. A few optimizations are included to vectorize operations, speeding them up over using `.apply` or `.transform` methods on the `Dataset` inputs.

Lastly, a Ruff extension was added to VS Code to auto-format on save instead of needing to always run the nox linter session. This session is still important to keep in the `pre-commit` session and for the `ci` workflow, but it is also convenient to improve formatting while working on the codebase too. To ensure consistent rules, the `.vscode` folder was removed from `.gitignore` and now includes local settings and extensions that override global settings. The rules in `settings.json` align with those in the `pyproject.toml`, which is what the `nox` session refers to.

## Type of change
- [x] New feature (non-breaking change which adds functionality)
- [x] Optimization (back-end change that improves speed/readability/etc.)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (any other clean up, maintenance, etc.)

# Key checklist:
- [x] No style issues: `$ nox -s linter [-- format]`
- [x] Code is free of misspellings: `$ nox -s codespell [-- write]`
- [x] All tests pass: `$ nox -s tests`

## Further checks:
- [x] The documentation builds: `$ nox -s docs`.
- [x] Code is commented, particularly in hard-to-understand areas.
- [x] Tests are added that prove fix is effective or that feature works.